### PR TITLE
Remove the classifiers section from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,4 @@ setup(
     keywords="cstruct struct dissect structure binary pack packer unpack unpacker parser parsing",
     url="https://github.com/fox-it/dissect.cstruct",
     packages=["dissect.cstruct", "dissect.cstruct.types"],
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-    ],
 )


### PR DESCRIPTION
It is duplicate and is part of setup.cfg.

(DIS-1499)