### PR TITLE
Add (u)int128 type to `cstruct.py`

### DIFF
--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -129,13 +129,15 @@ class cstruct:
             "uint16_t": "uint16",
             "uint32_t": "uint32",
             "uint64_t": "uint64",
-            "uint128_t": "int128",
+            "uint128_t": "uint128",
+            "unsigned __int128": "uint128",
 
             # Other convenience types
             "u1": "uint8",
             "u2": "uint16",
             "u4": "uint32",
             "u8": "uint64",
+            "u16": "uint128",
             "uchar": "uint8",
             "ushort": "unsigned short",
             "uint": "unsigned int",

--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -55,6 +55,8 @@ class cstruct:
             "uint24": BytesInteger(self, "uint24", 3, False, alignment=4),
             "int48": BytesInteger(self, "int48", 6, True, alignment=8),
             "uint48": BytesInteger(self, "uint48", 6, False, alignment=8),
+            "int128": BytesInteger(self, "int128", 16, True, alignment=16),
+            "uint128": BytesInteger(self, "uint128", 16, False, alignment=16),
 
             "void": VoidType(),
 

--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -87,6 +87,7 @@ class cstruct:
             "LONG64": "int64",
             "LONGLONG": "int64",
             "QWORD": "uint64",
+            "OWORD": "uint128",
             "WCHAR": "wchar",
 
             "UCHAR": "uint8",
@@ -100,17 +101,20 @@ class cstruct:
             "INT16": "int16",
             "INT32": "int32",
             "INT64": "int64",
+            "INT128": "int128",
 
             "UINT": "uint",
             "UINT8": "uint8",
             "UINT16": "uint16",
             "UINT32": "uint32",
             "UINT64": "uint64",
+            "UINT128": "uint128",
 
             "__int8": "int8",
             "__int16": "int16",
             "__int32": "int32",
             "__int64": "int64",
+            "__int128": "int128",
 
             "wchar_t": "wchar",
 
@@ -119,11 +123,13 @@ class cstruct:
             "int16_t": "int16",
             "int32_t": "int32",
             "int64_t": "int64",
+            "int128_t": "int128",
 
             "uint8_t": "uint8",
             "uint16_t": "uint16",
             "uint32_t": "uint32",
             "uint64_t": "uint64",
+            "uint128_t": "int128",
 
             # Other convenience types
             "u1": "uint8",


### PR DESCRIPTION
(DIS-1665)

Added the (u)int128 type to the list of types in `cstruct.py`, this was encountered while parsing some x64 PDBs.