### PR TITLE
Check if field is pointer before checking if field is an array

### DIFF
--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -51,7 +51,7 @@ class {name}(Structure):
         self.source = source
         super().__init__(cstruct, structure.name, structure.fields, anonymous=structure.anonymous)
 
-    def _read(self, stream):
+    def _read(self, stream, context=None):
         r = OrderedDict()
         sizes = {{}}
         bitreader = BitBuffer(stream, self.cstruct.endian)

--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -307,7 +307,7 @@ class {name}(Structure):
             elif isinstance(field_type, Pointer):
                 getter = f"PointerInstance(self.cstruct.{field_type.type.name}, stream, {getter}, r)"
             elif isinstance(field_type, Array) and isinstance(field_type.type, Pointer):
-                getter = f"[PointerInstance(self.cstruct.{field_type.type.name}, stream, d, r) for d in {getter}]"
+                getter = f"[PointerInstance(self.cstruct.{field_type.type.type.name}, stream, d, r) for d in {getter}]"
             elif isinstance(field_type, Array) and isinstance(read_type, PackedType):
                 getter = f"list({getter})"
 

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -245,6 +245,11 @@ class TokenParser(Parser):
 
         name = d["name"]
         count = d["count"]
+
+        if name.startswith("*"):
+            name = name[1:]
+            type_ = Pointer(self.cstruct, type_)
+
         if count is not None:
             if count == "":
                 count = None
@@ -256,10 +261,6 @@ class TokenParser(Parser):
                     pass
 
             type_ = Array(self.cstruct, type_, count)
-
-        if name.startswith("*"):
-            name = name[1:]
-            type_ = Pointer(self.cstruct, type_)
 
         tokens.eol()
         return Field(name, type_, int(d["bits"]) if d["bits"] else None)

--- a/dissect/cstruct/types/base.py
+++ b/dissect/cstruct/types/base.py
@@ -81,13 +81,13 @@ class BaseType:
         """
         return self._write(stream, data)
 
-    def _read(self, stream: BinaryIO) -> Any:
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> Any:
         raise NotImplementedError()
 
-    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> List[Any]:
-        return [self._read(stream) for _ in range(count)]
+    def _read_array(self, stream: BinaryIO, count: int, context: dict[str, Any] = None) -> List[Any]:
+        return [self._read(stream, context) for _ in range(count)]
 
-    def _read_0(self, stream: BinaryIO) -> List[Any]:
+    def _read_0(self, stream: BinaryIO, context: dict[str, Any] = None) -> List[Any]:
         raise NotImplementedError()
 
     def _write(self, stream: BinaryIO, data: Any) -> int:
@@ -143,16 +143,16 @@ class Array(BaseType):
 
         return len(self.type) * self.count
 
-    def _read(self, stream: BinaryIO, context: dict = None) -> List[Any]:
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> List[Any]:
         if self.null_terminated:
-            return self.type._read_0(stream)
+            return self.type._read_0(stream, context)
 
         if self.dynamic:
             count = self.count.evaluate(context)
         else:
             count = self.count
 
-        return self.type._read_array(stream, max(0, count), ctx=context)
+        return self.type._read_array(stream, max(0, count), context)
 
     def _write(self, stream: BinaryIO, data: List[Any]) -> int:
         if self.null_terminated:
@@ -183,10 +183,10 @@ class RawType(BaseType):
 
         return BaseType.__repr__(self)
 
-    def _read(self, stream: BinaryIO) -> Any:
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> Any:
         raise NotImplementedError()
 
-    def _read_0(self, stream: BinaryIO) -> List[Any]:
+    def _read_0(self, stream: BinaryIO, context: dict[str, Any] = None) -> List[Any]:
         raise NotImplementedError()
 
     def _write(self, stream: BinaryIO, data: Any) -> int:

--- a/dissect/cstruct/types/base.py
+++ b/dissect/cstruct/types/base.py
@@ -84,7 +84,7 @@ class BaseType:
     def _read(self, stream: BinaryIO) -> Any:
         raise NotImplementedError()
 
-    def _read_array(self, stream: BinaryIO, count: int) -> List[Any]:
+    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> List[Any]:
         return [self._read(stream) for _ in range(count)]
 
     def _read_0(self, stream: BinaryIO) -> List[Any]:
@@ -152,7 +152,7 @@ class Array(BaseType):
         else:
             count = self.count
 
-        return self.type._read_array(stream, max(0, count))
+        return self.type._read_array(stream, max(0, count), ctx=context)
 
     def _write(self, stream: BinaryIO, data: List[Any]) -> int:
         if self.null_terminated:

--- a/dissect/cstruct/types/bytesinteger.py
+++ b/dissect/cstruct/types/bytesinteger.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import BinaryIO, List, TYPE_CHECKING
+from typing import Any, BinaryIO, List, TYPE_CHECKING
 
 from dissect.cstruct.types import RawType
 
@@ -76,10 +76,10 @@ class BytesInteger(RawType):
 
         return b"".join(buf)
 
-    def _read(self, stream: BinaryIO) -> int:
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> int:
         return self.parse(stream.read(self.size * 1), self.size, 1, self.signed, self.cstruct.endian)[0]
 
-    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> List[int]:
+    def _read_array(self, stream: BinaryIO, count: int, context: dict[str, Any] = None) -> List[int]:
         return self.parse(
             stream.read(self.size * count),
             self.size,
@@ -88,11 +88,11 @@ class BytesInteger(RawType):
             self.cstruct.endian,
         )
 
-    def _read_0(self, stream: BinaryIO) -> List[int]:
+    def _read_0(self, stream: BinaryIO, context: dict[str, Any] = None) -> List[int]:
         result = []
 
         while True:
-            v = self._read(stream)
+            v = self._read(stream, context)
             if v == 0:
                 break
 

--- a/dissect/cstruct/types/bytesinteger.py
+++ b/dissect/cstruct/types/bytesinteger.py
@@ -79,7 +79,7 @@ class BytesInteger(RawType):
     def _read(self, stream: BinaryIO) -> int:
         return self.parse(stream.read(self.size * 1), self.size, 1, self.signed, self.cstruct.endian)[0]
 
-    def _read_array(self, stream: BinaryIO, count: int) -> List[int]:
+    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> List[int]:
         return self.parse(
             stream.read(self.size * count),
             self.size,

--- a/dissect/cstruct/types/chartype.py
+++ b/dissect/cstruct/types/chartype.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import BinaryIO, TYPE_CHECKING
+from typing import Any, BinaryIO, TYPE_CHECKING
 
 from dissect.cstruct.types import RawType
 
@@ -14,16 +14,16 @@ class CharType(RawType):
     def __init__(self, cstruct: cstruct):
         super().__init__(cstruct, "char", size=1, alignment=1)
 
-    def _read(self, stream: BinaryIO) -> bytes:
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> bytes:
         return stream.read(1)
 
-    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> bytes:
+    def _read_array(self, stream: BinaryIO, count: int, context: dict[str, Any] = None) -> bytes:
         if count == 0:
             return b""
 
         return stream.read(count)
 
-    def _read_0(self, stream: BinaryIO) -> bytes:
+    def _read_0(self, stream: BinaryIO, context: dict[str, Any] = None) -> bytes:
         byte_array = []
         while True:
             bytes_stream = stream.read(1)

--- a/dissect/cstruct/types/chartype.py
+++ b/dissect/cstruct/types/chartype.py
@@ -17,7 +17,7 @@ class CharType(RawType):
     def _read(self, stream: BinaryIO) -> bytes:
         return stream.read(1)
 
-    def _read_array(self, stream: BinaryIO, count: int) -> bytes:
+    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> bytes:
         if count == 0:
             return b""
 

--- a/dissect/cstruct/types/enum.py
+++ b/dissect/cstruct/types/enum.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import BinaryIO, Dict, List, Union, TYPE_CHECKING
+from typing import Any, BinaryIO, Dict, List, Union, TYPE_CHECKING
 
 from dissect.cstruct.types import BaseType, RawType
 
@@ -55,17 +55,15 @@ class Enum(RawType):
     def __contains__(self, attr: str) -> bool:
         return attr in self.values
 
-    def _read(self, stream: BinaryIO) -> EnumInstance:
-        v = self.type._read(
-            stream,
-        )
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> EnumInstance:
+        v = self.type._read(stream, context)
         return self(v)
 
-    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> List[EnumInstance]:
-        return list(map(self, self.type._read_array(stream, count)))
+    def _read_array(self, stream: BinaryIO, count: int, context: dict[str, Any] = None) -> List[EnumInstance]:
+        return list(map(self, self.type._read_array(stream, count, context)))
 
-    def _read_0(self, stream: BinaryIO) -> List[EnumInstance]:
-        return list(map(self, self.type._read_0(stream)))
+    def _read_0(self, stream: BinaryIO, context: dict[str, Any] = None) -> List[EnumInstance]:
+        return list(map(self, self.type._read_0(stream, context)))
 
     def _write(self, stream: BinaryIO, data: Union[int, EnumInstance]) -> int:
         data = data.value if isinstance(data, EnumInstance) else data

--- a/dissect/cstruct/types/enum.py
+++ b/dissect/cstruct/types/enum.py
@@ -61,7 +61,7 @@ class Enum(RawType):
         )
         return self(v)
 
-    def _read_array(self, stream: BinaryIO, count: int) -> List[EnumInstance]:
+    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> List[EnumInstance]:
         return list(map(self, self.type._read_array(stream, count)))
 
     def _read_0(self, stream: BinaryIO) -> List[EnumInstance]:

--- a/dissect/cstruct/types/packedtype.py
+++ b/dissect/cstruct/types/packedtype.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import struct
-from typing import BinaryIO, List, TYPE_CHECKING
+from typing import Any, BinaryIO, List, TYPE_CHECKING
 
 from dissect.cstruct.types import RawType
 
@@ -16,10 +16,10 @@ class PackedType(RawType):
         super().__init__(cstruct, name, size, alignment)
         self.packchar = packchar
 
-    def _read(self, stream: BinaryIO) -> int:
-        return self._read_array(stream, 1)[0]
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> int:
+        return self._read_array(stream, 1, context)[0]
 
-    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> List[int]:
+    def _read_array(self, stream: BinaryIO, count: int, context: dict[str, Any] = None) -> List[int]:
         length = self.size * count
         data = stream.read(length)
         fmt = self.cstruct.endian + str(count) + self.packchar
@@ -29,7 +29,7 @@ class PackedType(RawType):
 
         return list(struct.unpack(fmt, data))
 
-    def _read_0(self, stream: BinaryIO) -> List[int]:
+    def _read_0(self, stream: BinaryIO, context: dict[str, Any] = None) -> List[int]:
         byte_array = []
         while True:
             bytes_stream = stream.read(self.size)

--- a/dissect/cstruct/types/packedtype.py
+++ b/dissect/cstruct/types/packedtype.py
@@ -19,7 +19,7 @@ class PackedType(RawType):
     def _read(self, stream: BinaryIO) -> int:
         return self._read_array(stream, 1)[0]
 
-    def _read_array(self, stream: BinaryIO, count: int) -> List[int]:
+    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> List[int]:
         length = self.size * count
         data = stream.read(length)
         fmt = self.cstruct.endian + str(count) + self.packchar

--- a/dissect/cstruct/types/pointer.py
+++ b/dissect/cstruct/types/pointer.py
@@ -21,12 +21,9 @@ class Pointer(RawType):
     def __repr__(self) -> str:
         return f"<Pointer {self.type}>"
 
-    def _read(self, stream: BinaryIO, ctx: Dict[str, Any]) -> PointerInstance:
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> PointerInstance:
         addr = self.cstruct.pointer(stream)
-        return PointerInstance(self.type, stream, addr, ctx)
-
-    def _read_array(self, stream: BinaryIO, count: int, ctx: Dict[str, Any]) -> List[Pointer]:
-        return [ self._read(stream, ctx) for _ in range(count) ]
+        return PointerInstance(self.type, stream, addr, context)
 
     def _write(self, stream: BinaryIO, data: Union[int, PointerInstance]):
         if isinstance(data, PointerInstance):
@@ -118,15 +115,11 @@ class PointerInstance:
             # Reposition the file read/write pointer
             self._stream.seek(self._addr)
 
-            if isinstance(self._type, Array):
-                value = self._type._read(self._stream, self._ctx)
-            elif isinstance(self._type, CharType):
+            if isinstance(self._type, CharType):
                 # this makes the assumption that a char pointer is a null-terminated string
-                value = self._type._read_0(self._stream)
+                value = self._type._read_0(self._stream, self._ctx)
             else:
-                value = self._type._read(
-                    self._stream,
-                )
+                value = self._type._read(self._stream, self._ctx)
 
             self._stream.seek(position)
             self._value = value

--- a/dissect/cstruct/types/pointer.py
+++ b/dissect/cstruct/types/pointer.py
@@ -4,7 +4,7 @@ import operator
 from typing import Any, BinaryIO, Callable, Dict, Union, TYPE_CHECKING
 
 from dissect.cstruct.exceptions import NullPointerDereference
-from dissect.cstruct.types import Array, BaseType, RawType
+from dissect.cstruct.types import Array, BaseType, CharType, RawType
 
 if TYPE_CHECKING:
     from dissect.cstruct import cstruct
@@ -120,6 +120,9 @@ class PointerInstance:
 
             if isinstance(self._type, Array):
                 value = self._type._read(self._stream, self._ctx)
+            elif isinstance(self._type, CharType):
+                # this makes the assumption that a char pointer is a null-terminated string
+                value = self._type._read_0(self._stream)
             else:
                 value = self._type._read(
                     self._stream,

--- a/dissect/cstruct/types/pointer.py
+++ b/dissect/cstruct/types/pointer.py
@@ -4,7 +4,7 @@ import operator
 from typing import Any, BinaryIO, Callable, Dict, Union, TYPE_CHECKING
 
 from dissect.cstruct.exceptions import NullPointerDereference
-from dissect.cstruct.types import Array, BaseType, CharType, RawType
+from dissect.cstruct.types import BaseType, CharType, RawType
 
 if TYPE_CHECKING:
     from dissect.cstruct import cstruct

--- a/dissect/cstruct/types/pointer.py
+++ b/dissect/cstruct/types/pointer.py
@@ -25,6 +25,9 @@ class Pointer(RawType):
         addr = self.cstruct.pointer(stream)
         return PointerInstance(self.type, stream, addr, ctx)
 
+    def _read_array(self, stream: BinaryIO, count: int, ctx: Dict[str, Any]) -> List[Pointer]:
+        return [ self._read(stream, ctx) for _ in range(count) ]
+
     def _write(self, stream: BinaryIO, data: Union[int, PointerInstance]):
         if isinstance(data, PointerInstance):
             data = data._addr

--- a/dissect/cstruct/types/voidtype.py
+++ b/dissect/cstruct/types/voidtype.py
@@ -1,3 +1,5 @@
+from typing import Any, BinaryIO
+
 from dissect.cstruct.types import RawType
 
 
@@ -7,5 +9,5 @@ class VoidType(RawType):
     def __init__(self):
         super().__init__(None, "void")
 
-    def _read(self, stream) -> None:
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> None:
         return None

--- a/dissect/cstruct/types/wchartype.py
+++ b/dissect/cstruct/types/wchartype.py
@@ -1,4 +1,4 @@
-from typing import BinaryIO
+from typing import Any, BinaryIO
 
 from dissect.cstruct.types import RawType
 
@@ -16,17 +16,17 @@ class WcharType(RawType):
         elif self.cstruct.endian == ">":  # big-endian (BE)
             return "utf-16-be"
 
-    def _read(self, stream: BinaryIO) -> str:
+    def _read(self, stream: BinaryIO, context: dict[str, Any] = None) -> str:
         return stream.read(2).decode(self.encoding)
 
-    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> str:
+    def _read_array(self, stream: BinaryIO, count: int, context: dict[str, Any] = None) -> str:
         if count == 0:
             return ""
 
         data = stream.read(2 * count)
         return data.decode(self.encoding)
 
-    def _read_0(self, stream: BinaryIO) -> str:
+    def _read_0(self, stream: BinaryIO, context: dict[str, Any] = None) -> str:
         byte_string = b""
         while True:
             bytes_stream = stream.read(2)

--- a/dissect/cstruct/types/wchartype.py
+++ b/dissect/cstruct/types/wchartype.py
@@ -19,7 +19,7 @@ class WcharType(RawType):
     def _read(self, stream: BinaryIO) -> str:
         return stream.read(2).decode(self.encoding)
 
-    def _read_array(self, stream: BinaryIO, count: int) -> str:
+    def _read_array(self, stream: BinaryIO, count: int, **kwargs) -> str:
         if count == 0:
             return ""
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -306,8 +306,8 @@ def test_half_compiled_struct():
             self._t = cstruct_obj.uint64
             super().__init__(cstruct_obj, "OffByOne", 8)
 
-        def _read(self, stream):
-            return self._t._read(stream) + 1
+        def _read(self, stream, context=None):
+            return self._t._read(stream, context) + 1
 
         def _write(self, stream, data):
             return self._t._write(stream, data - 1)

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -8,42 +8,42 @@ from .utils import verify_compiled
 
 @pytest.mark.parametrize("compiled", [True, False])
 def test_pointer_basic(compiled):
-    d = """
+    cdef = """
     struct ptrtest {
         uint32  *ptr1;
         uint32  *ptr2;
     };
     """
-    c = cstruct.cstruct(pointer="uint16")
-    c.load(d, compiled=compiled)
+    cs = cstruct.cstruct(pointer="uint16")
+    cs.load(cdef, compiled=compiled)
 
-    assert verify_compiled(c.ptrtest, compiled)
+    assert verify_compiled(cs.ptrtest, compiled)
 
-    d = b"\x04\x00\x08\x00\x01\x02\x03\x04\x05\x06\x07\x08"
-    p = c.ptrtest(d)
+    buf = b"\x04\x00\x08\x00\x01\x02\x03\x04\x05\x06\x07\x08"
+    obj = cs.ptrtest(buf)
 
-    assert p.ptr1 != 0
-    assert p.ptr2 != 0
-    assert p.ptr1 != p.ptr2
-    assert p.ptr1 == 4
-    assert p.ptr2 == 8
-    assert p.ptr1.dereference() == 0x04030201
-    assert p.ptr2.dereference() == 0x08070605
+    assert obj.ptr1 != 0
+    assert obj.ptr2 != 0
+    assert obj.ptr1 != obj.ptr2
+    assert obj.ptr1 == 4
+    assert obj.ptr2 == 8
+    assert obj.ptr1.dereference() == 0x04030201
+    assert obj.ptr2.dereference() == 0x08070605
 
-    p.ptr1 += 2
-    p.ptr2 -= 2
-    assert p.ptr1 == p.ptr2
-    assert p.ptr1.dereference() == p.ptr2.dereference() == 0x06050403
+    obj.ptr1 += 2
+    obj.ptr2 -= 2
+    assert obj.ptr1 == obj.ptr2
+    assert obj.ptr1.dereference() == obj.ptr2.dereference() == 0x06050403
 
-    assert p.dumps() == b"\x06\x00\x06\x00"
+    assert obj.dumps() == b"\x06\x00\x06\x00"
 
     with pytest.raises(cstruct.NullPointerDereference):
-        c.ptrtest(b"\x00\x00\x00\x00").ptr1.dereference()
+        cs.ptrtest(b"\x00\x00\x00\x00").ptr1.dereference()
 
 
 @pytest.mark.parametrize("compiled", [True, False])
 def test_pointer_struct(compiled):
-    d = """
+    cdef = """
     struct test {
         char    magic[4];
         wchar   wmagic[4];
@@ -58,52 +58,52 @@ def test_pointer_struct(compiled):
         test    *ptr;
     };
     """
-    c = cstruct.cstruct(pointer="uint16")
-    c.load(d, compiled=compiled)
+    cs = cstruct.cstruct(pointer="uint16")
+    cs.load(cdef, compiled=compiled)
 
-    assert verify_compiled(c.test, compiled)
-    assert verify_compiled(c.ptrtest, compiled)
+    assert verify_compiled(cs.test, compiled)
+    assert verify_compiled(cs.ptrtest, compiled)
 
-    d = b"\x02\x00testt\x00e\x00s\x00t\x00\x01\x02\x03\x04\x05\x06\x07lalala\x00t\x00e\x00s\x00t\x00\x00\x00"
-    p = c.ptrtest(d)
+    buf = b"\x02\x00testt\x00e\x00s\x00t\x00\x01\x02\x03\x04\x05\x06\x07lalala\x00t\x00e\x00s\x00t\x00\x00\x00"
+    obj = cs.ptrtest(buf)
 
-    assert p.ptr != 0
+    assert obj.ptr != 0
 
-    assert p.ptr.magic == b"test"
-    assert p.ptr.wmagic == "test"
-    assert p.ptr.a == 0x01
-    assert p.ptr.b == 0x0302
-    assert p.ptr.c == 0x07060504
-    assert p.ptr.string == b"lalala"
-    assert p.ptr.wstring == "test"
+    assert obj.ptr.magic == b"test"
+    assert obj.ptr.wmagic == "test"
+    assert obj.ptr.a == 0x01
+    assert obj.ptr.b == 0x0302
+    assert obj.ptr.c == 0x07060504
+    assert obj.ptr.string == b"lalala"
+    assert obj.ptr.wstring == "test"
 
-    assert p.dumps() == b"\x02\x00"
+    assert obj.dumps() == b"\x02\x00"
 
     with pytest.raises(cstruct.NullPointerDereference):
-        c.ptrtest(b"\x00\x00\x00\x00").ptr.magic
+        cs.ptrtest(b"\x00\x00\x00\x00").ptr.magic
 
 
 @pytest.mark.parametrize("compiled", [True, False])
 def test_array_of_pointers(compiled):
-    d = """
+    cdef = """
     struct mainargs {
         uint8_t argc;
         char *args[4];
     }
     """
-    c = cstruct.cstruct(pointer="uint16")
-    c.load(d, compiled=compiled)
+    cs = cstruct.cstruct(pointer="uint16")
+    cs.load(cdef, compiled=compiled)
 
-    assert verify_compiled(c.mainargs, compiled)
+    assert verify_compiled(cs.mainargs, compiled)
 
-    d = b"\x02\x09\x00\x16\x00\x00\x00\x00\x00argument one\x00argument two\x00"
-    p = c.mainargs(d)
+    buf = b"\x02\x09\x00\x16\x00\x00\x00\x00\x00argument one\x00argument two\x00"
+    obj = cs.mainargs(buf)
 
-    assert p.argc == 2
-    assert p.args[2] == 0
-    assert p.args[3] == 0
-    assert p.args[0].dereference() == b'argument one'
-    assert p.args[1].dereference() == b'argument two'
+    assert obj.argc == 2
+    assert obj.args[2] == 0
+    assert obj.args[3] == 0
+    assert obj.args[0].dereference() == b'argument one'
+    assert obj.args[1].dereference() == b'argument two'
 
 
 def test_pointer_arithmetic():

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -83,6 +83,29 @@ def test_pointer_struct(compiled):
         c.ptrtest(b"\x00\x00\x00\x00").ptr.magic
 
 
+@pytest.mark.parametrize("compiled", [True, False])
+def test_array_of_pointers(compiled):
+    d = """
+    struct mainargs {
+        uint8_t argc;
+        char *args[4];
+    }
+    """
+    c = cstruct.cstruct(pointer="uint16")
+    c.load(d, compiled=compiled)
+
+    assert verify_compiled(c.mainargs, compiled)
+
+    d = b"\x02\x09\x00\x16\x00\x00\x00\x00\x00argument one\x00argument two\x00"
+    p = c.mainargs(d)
+
+    assert p.argc == 2
+    assert p.args[2] == 0
+    assert p.args[3] == 0
+    assert p.args[0].dereference() == b'argument one'
+    assert p.args[1].dereference() == b'argument two'
+
+
 def test_pointer_arithmetic():
     inst = PointerInstance(None, None, 0, None)
     assert inst._addr == 0

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -102,8 +102,8 @@ def test_array_of_pointers(compiled):
     assert obj.argc == 2
     assert obj.args[2] == 0
     assert obj.args[3] == 0
-    assert obj.args[0].dereference() == b'argument one'
-    assert obj.args[1].dereference() == b'argument two'
+    assert obj.args[0].dereference() == b"argument one"
+    assert obj.args[1].dereference() == b"argument two"
 
 
 def test_pointer_arithmetic():


### PR DESCRIPTION
Considering the following field definition:

```c
char *text[AUDIT_MAX_ARGS];
```

Previously, `TokenParser._parse_field` would first check if a field is an array, and then if a field is a pointer. This would result in the field being interpreted as a pointer to an array. However, this should have been interpreted as an array of pointers.

This issue became prevalent in `Compiler.gen_read_block`, that would first check if a field's type is Pointer and only then if the field's type is an Array of Pointers. As far as I can tell, this condition cannot be reached with the current implementation of `_parse_field`.

This change performs the check if the field is a pointer before the check if the field is an array. This would result in the field being interpreted as an Array of Pointers.