### PR TITLE
Fix bitbuffer to support `char`

### DIFF
--- a/tests/test_bitfield.py
+++ b/tests/test_bitfield.py
@@ -246,3 +246,29 @@ def test_bitfield_with_enum_or_flag(compiled):
     assert obj.d == cs.Flag8.A | cs.Flag8.B
 
     assert obj.dumps() == buf
+
+
+def test_bitfield_char(compiled):
+    cdef = """
+    struct test {
+        uint16  a : 4;
+        uint16  b : 4;
+        char    c : 4;
+        char    d[4];
+    };
+    """
+
+    cs = cstruct.cstruct()
+    cs.load(cdef)
+
+    assert verify_compiled(cs.test, compiled)
+
+    buf = b"\x12\x34\xff\x69420"
+    obj = cs.test(buf)
+
+    assert obj.a == 0b10
+    assert obj.b == 0b1
+    assert obj.c == 0b1111
+    assert obj.d == b"i420"
+
+    assert obj.dumps() == buf

--- a/tests/test_bitfield.py
+++ b/tests/test_bitfield.py
@@ -261,7 +261,7 @@ def test_bitfield_char(compiled):
     cs = cstruct.cstruct()
     cs.load(cdef, compiled=compiled)
 
-    assert verify_compiled(cs.test, compiled=compiled)
+    assert verify_compiled(cs.test, compiled)
 
     buf = b"\x12\x00\xff\x69420"
     obj = cs.test(buf)

--- a/tests/test_bitfield.py
+++ b/tests/test_bitfield.py
@@ -253,22 +253,22 @@ def test_bitfield_char(compiled):
     struct test {
         uint16  a : 4;
         uint16  b : 4;
-        char    c : 4;
+        char    c : 8;
         char    d[4];
     };
     """
 
     cs = cstruct.cstruct()
-    cs.load(cdef)
+    cs.load(cdef, compiled=compiled)
 
-    assert verify_compiled(cs.test, compiled)
+    assert verify_compiled(cs.test, compiled=compiled)
 
-    buf = b"\x12\x34\xff\x69420"
+    buf = b"\x12\x00\xff\x69420"
     obj = cs.test(buf)
 
     assert obj.a == 0b10
     assert obj.b == 0b1
-    assert obj.c == 0b1111
+    assert obj.c == 0b11111111
     assert obj.d == b"i420"
 
     assert obj.dumps() == buf


### PR DESCRIPTION
(DIS-1674)

Added check to see if a field is a `char` type and convert the field to int so we can perform bitwise operations.

Also changed the check for the little vs big endianness as it was first checking if it wasn't big endian, improves reading the code.