### PR TITLE
Raise an exception when the static size of an array field does not match the size of the provided list instead of silently writing incorrectly sized data.

### DIFF
--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import struct
 from collections import OrderedDict
 from textwrap import dedent
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from dissect.cstruct.bitbuffer import BitBuffer
 from dissect.cstruct.expression import Expression
@@ -122,7 +122,6 @@ class {name}(Structure):
             if isinstance(field_type, Structure) or (
                 isinstance(field_type, Array) and isinstance(field_type.type, (Structure, Array))
             ):
-
                 blocks.append(self.gen_read_block(read_size, cur_block))
 
                 struct_read = "s = stream.tell()\n"

--- a/dissect/cstruct/exceptions.py
+++ b/dissect/cstruct/exceptions.py
@@ -14,6 +14,5 @@ class NullPointerDereference(Error):
     pass
 
 
-class ArraySizeMismatch(Error):
+class ArraySizeError(Error):
     pass
-

--- a/dissect/cstruct/exceptions.py
+++ b/dissect/cstruct/exceptions.py
@@ -12,3 +12,8 @@ class ResolveError(Error):
 
 class NullPointerDereference(Error):
     pass
+
+
+class ArraySizeMismatch(Error):
+    pass
+

--- a/dissect/cstruct/types/base.py
+++ b/dissect/cstruct/types/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from io import BytesIO
 from typing import Any, BinaryIO, List, TYPE_CHECKING
 
-from dissect.cstruct.exceptions import ArraySizeMismatch
+from dissect.cstruct.exceptions import ArraySizeError
 from dissect.cstruct.expression import Expression
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ class BaseType:
             The resulting bytes.
 
         Raises:
-            ArraySizeMismatch: Raised when len(data) does not match the size of a statically sized array field.
+            ArraySizeError: Raised when ``len(data)`` does not match the size of a statically sized array field.
         """
         out = BytesIO()
         self._write(out, data)
@@ -84,7 +84,7 @@ class BaseType:
             The amount of bytes written.
 
         Raises:
-            ArraySizeMismatch: Raised when len(data) does not match the size of a statically sized array field.
+            ArraySizeError: Raised when ``len(data)`` does not match the size of a statically sized array field.
         """
         return self._write(stream, data)
 
@@ -165,8 +165,8 @@ class Array(BaseType):
         if self.null_terminated:
             return self.type._write_0(stream, data)
 
-        if not self.dynamic and self.count != (arr_size := len(data)):
-            raise ArraySizeMismatch(f"Expected static array size {self.count}, got {arr_size} instead.")
+        if not self.dynamic and self.count != (actual_size := len(data)):
+            raise ArraySizeError(f"Expected static array size {self.count}, got {actual_size} instead.")
 
         return self.type._write_array(stream, data)
 

--- a/dissect/cstruct/types/base.py
+++ b/dissect/cstruct/types/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from io import BytesIO
 from typing import Any, BinaryIO, List, TYPE_CHECKING
 
+from dissect.cstruct.exceptions import ArraySizeMismatch
 from dissect.cstruct.expression import Expression
 
 if TYPE_CHECKING:
@@ -49,6 +50,9 @@ class BaseType:
 
         Returns:
             The resulting bytes.
+
+        Raises:
+            ArraySizeMismatch: Raised when len(data) does not match the size of a statically sized array field.
         """
         out = BytesIO()
         self._write(out, data)
@@ -78,6 +82,9 @@ class BaseType:
 
         Returns:
             The amount of bytes written.
+
+        Raises:
+            ArraySizeMismatch: Raised when len(data) does not match the size of a statically sized array field.
         """
         return self._write(stream, data)
 
@@ -157,6 +164,9 @@ class Array(BaseType):
     def _write(self, stream: BinaryIO, data: List[Any]) -> int:
         if self.null_terminated:
             return self.type._write_0(stream, data)
+
+        if not self.dynamic and self.count != (arr_size := len(data)):
+            raise ArraySizeMismatch(f"Expected static array size {self.count}, got {arr_size} instead.")
 
         return self.type._write_array(stream, data)
 

--- a/dissect/cstruct/types/bytesinteger.py
+++ b/dissect/cstruct/types/bytesinteger.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, BinaryIO, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, BinaryIO, List
 
 from dissect.cstruct.types import RawType
 
@@ -48,7 +48,6 @@ class BytesInteger(RawType):
         signed_max = (2 ** (bits - 1)) - 1
 
         for i in data:
-
             if signed and (i < signed_min or i > signed_max):
                 raise OverflowError(f"{i} exceeds bounds for signed {bits} bits BytesInteger")
             elif not signed and (i < unsigned_min or i > unsigned_max):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from dissect import cstruct
 
-from dissect.cstruct.exceptions import ParserError, ResolveError
+from dissect.cstruct.exceptions import ArraySizeMismatch, ParserError, ResolveError
 
 from .utils import verify_compiled
 
@@ -500,3 +500,18 @@ def test_array_three_dimensional(compiled):
     assert obj.a[1][1][1] == 8
 
     assert obj.dumps() == buf
+
+
+def test_report_array_size_mismatch():
+    d = """
+    struct test {
+        uint8   a[2];
+    };
+    """
+    c = cstruct.cstruct(endian=">")
+    c.load(d)
+
+    a = c.test(a=[1, 2, 3])
+
+    with pytest.raises(ArraySizeMismatch):
+        a.dumps()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -503,15 +503,15 @@ def test_array_three_dimensional(compiled):
 
 
 def test_report_array_size_mismatch():
-    d = """
+    cdef = """
     struct test {
         uint8   a[2];
     };
     """
-    c = cstruct.cstruct(endian=">")
-    c.load(d)
+    cs = cstruct.cstruct(endian=">")
+    cs.load(cdef)
 
-    a = c.test(a=[1, 2, 3])
+    a = cs.test(a=[1, 2, 3])
 
     with pytest.raises(ArraySizeMismatch):
         a.dumps()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from dissect import cstruct
 
-from dissect.cstruct.exceptions import ArraySizeMismatch, ParserError, ResolveError
+from dissect.cstruct.exceptions import ArraySizeError, ParserError, ResolveError
 
 from .utils import verify_compiled
 
@@ -513,5 +513,5 @@ def test_report_array_size_mismatch():
 
     a = cs.test(a=[1, 2, 3])
 
-    with pytest.raises(ArraySizeMismatch):
+    with pytest.raises(ArraySizeError):
         a.dumps()


### PR DESCRIPTION
Addresses issue #22.