### PR TITLE
Make the Instance class dict compatible to allow for JSON serialization.

### DIFF
--- a/dissect/cstruct/types/enum.py
+++ b/dissect/cstruct/types/enum.py
@@ -84,12 +84,14 @@ class Enum(RawType):
         return [self.default() for _ in range(count)]
 
 
-class EnumInstance:
+class EnumInstance(dict):
     """Implements a value instance of an Enum"""
 
     def __init__(self, enum: Enum, value: int):
         self.enum = enum
         self.value = value
+        kwargs = {self.enum.name : self.value}
+        dict.__init__(self, **kwargs)
 
     def __eq__(self, value: Union[int, EnumInstance]) -> bool:
         if isinstance(value, EnumInstance) and value.enum is not self.enum:

--- a/dissect/cstruct/types/instance.py
+++ b/dissect/cstruct/types/instance.py
@@ -4,12 +4,13 @@ from typing import Any, BinaryIO, Dict
 from dissect.cstruct.types import BaseType
 
 
-class Instance:
+class Instance(dict):
     """Holds parsed structure data."""
 
     __slots__ = ("_type", "_values", "_sizes")
 
     def __init__(self, type_: BaseType, values: Dict[str, Any], sizes: Dict[str, int] = None):
+        dict.__init__(self, **values)
         # Done in this manner to check if the attr is in the lookup
         object.__setattr__(self, "_type", type_)
         object.__setattr__(self, "_values", values)
@@ -45,6 +46,9 @@ class Instance:
 
     def _size(self, field: str) -> int:
         return self._sizes[field]
+
+    def __iter__(self):
+        yield from self._values.items()
 
     def write(self, stream: BinaryIO) -> int:
         """Write this structure to a writable file-like object.

--- a/examples/mirai_json.py
+++ b/examples/mirai_json.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+from dissect.cstruct import cstruct, dumpstruct
+
+import json
+import socket
+import struct
+
+class CustomEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            return obj.decode('utf-8', errors='surrogateescape')
+        return json.JSONEncoder.default(self, obj)
+
+protocol = cstruct()
+
+protocol.load(
+    """
+enum AttackType : uint8 {
+    ATK_OPT_DPORT =  7,
+    ATK_OPT_DOMAIN  =  8,
+    ATK_OPT_NUM_SOCKETS =  24,
+};
+
+struct AttackTarget {
+    DWORD   ipv4;
+    BYTE    netmask;
+};
+
+struct AttackOption {
+    AttackType   type;
+    uint8   value_length;
+    char    value[value_length];
+};
+
+struct MiraiAttack {
+    uint16  total_length;
+    uint32  duration;
+    uint8   attack_id;
+    uint8   target_count;
+    AttackTarget targets[target_count];
+    uint8   num_opts;
+    AttackOption attack_options[num_opts];
+};
+"""
+)
+
+protocol.endian = ">"
+
+if __name__ == "__main__":
+    data = b"\x000\x00\x00\x00d\n\x01\x08\x08\x08\x08 \x03\x08\x16http://www.example.com\x07\x0280\x18\x045000"
+
+    record = protocol.MiraiAttack(data)
+    print(json.dumps(record, cls=CustomEncoder))


### PR DESCRIPTION
I have a specific use case where I want to serialize dissect.cstruct instances to JSON.

This MR introduces two changes to make both `Instance` and `EnumInstance` inherit from `dict`, allowing users of the library to do things like:

```python
my_struct = cstruct()
my_struct.load(definition)
record = my_struct.Record(data)
print(json.dumps(record, cls=CustomEncoder))
```

Since these instances can contain `bytes` attributes and that JSON does not support bytes, the specificities of the JSON encoding is left to the user of `dissect.cstruct`. In the attached example, a UTF-8 decoding with surrogate escape is used but we could also imagine a base64 encoding if the structure holds lots of raw binary data.

A demo example is provided in `examples/mirai_json.py`

These changes do not introduce API changes nor do they break the test suite. However, I'm open to writing unit tests if you're open to merge this MR :)

Thanks again for this wonderful project !