### PR TITLE
Anonymous enums

### DIFF
--- a/dissect/cstruct/expression.py
+++ b/dissect/cstruct/expression.py
@@ -79,6 +79,6 @@ class Expression:
             return int(buf, 16)
 
         if buf in self.cstruct.consts:
-            return self.cstruct.consts[buf]
+            return int(self.cstruct.consts[buf])
 
         return int(buf)

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -130,18 +130,17 @@ class TokenParser(Parser):
         if not d["type"]:
             d["type"] = "uint32"
 
-        if not d["name"] and enumtype == "enum":
-            for key in values.keys():
-                self.cstruct.consts[key] = values[key]
-            tokens.eol()
-            return
-
         enumcls = Enum
         if enumtype == "flag":
             enumcls = Flag
 
         enum = enumcls(self.cstruct, d["name"], self.cstruct.resolve(d["type"]), values)
-        self.cstruct.addtype(enum.name, enum)
+
+        if not enum.name:
+            for name, value in enum.values.items():
+                self.cstruct.consts[name] = enum(value)
+        else:
+            self.cstruct.addtype(enum.name, enum)
 
         tokens.eol()
 

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -54,7 +54,7 @@ class TokenParser(Parser):
         TOK.add(r"typedef(?=\s)", "TYPEDEF")
         TOK.add(r"(?:struct|union)(?=\s|{)", "STRUCT")
         TOK.add(
-            r"(?P<enumtype>enum|flag)\s+(?P<name>[^\s:{]+)\s*(:\s"
+            r"(?P<enumtype>enum|flag)\s+(?P<name>[^\s:{]+)?\s*(:\s"
             r"*(?P<type>[^{]+?)\s*)?\{(?P<values>[^}]+)\}\s*(?=;)",
             "ENUM",
         )
@@ -129,6 +129,12 @@ class TokenParser(Parser):
 
         if not d["type"]:
             d["type"] = "uint32"
+
+        if not d["name"] and enumtype == "enum":
+            for key in values.keys():
+                self.cstruct.consts[key] = values[key]
+            tokens.eol()
+            return
 
         enumcls = Enum
         if enumtype == "flag":

--- a/dissect/cstruct/types/enum.py
+++ b/dissect/cstruct/types/enum.py
@@ -109,8 +109,12 @@ class EnumInstance:
     def __str__(self) -> str:
         return f"{self.enum.name}.{self.name}"
 
+    def __int__(self) -> int:
+        return self.value
+
     def __repr__(self) -> str:
-        return f"<{self.enum.name}.{self.name}: {self.value}>"
+        name = f"{self.enum.name}.{self.name}" if self.enum.name else self.name
+        return f"<{name}: {self.value}>"
 
     @property
     def name(self) -> str:

--- a/dissect/cstruct/types/flag.py
+++ b/dissect/cstruct/types/flag.py
@@ -74,12 +74,14 @@ class FlagInstance(EnumInstance):
         return f"{self.enum.name}.{members_str}"
 
     def __repr__(self) -> str:
+        base_name = f"{self.enum.name}." if self.enum.name else ""
+
         if self.name is not None:
-            return f"<{self.enum.name}.{self.name}: {self.value}>"
+            return f"<{base_name}{self.name}: {self.value}>"
 
         members, _ = self.decompose()
         members_str = "|".join([str(name or value) for name, value in members])
-        return f"<{self.enum.name}.{members_str}: {self.value}>"
+        return f"<{base_name}{members_str}: {self.value}>"
 
     @property
     def name(self) -> str:

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -221,3 +221,38 @@ def test_enum_write(compiled):
     obj.list = [cs.Test16.A, cs.Test16.B]
 
     assert obj.dumps() == b"\x01\x00\x02\x00\x01\x00\x00\x02\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x01\x00\x02\x00"
+
+
+def test_enum_anonymous(compiled):
+    cdef = """
+    enum : uint16 {
+          RED = 1,
+          GREEN = 2,
+          BLUE = 3,
+    };
+    """
+    cs = cstruct.cstruct()
+    cs.load(cdef, compiled=compiled)
+
+    assert cs.RED == 1
+    assert cs.GREEN == 2
+    assert cs.BLUE == 3
+
+
+def test_enum_anonymous_struct(compiled):
+    cdef = """
+    enum : uint32 {
+          nElements = 4
+    };
+
+    struct test {
+        uint32  arr[nElements];
+    };
+    """
+    cs = cstruct.cstruct()
+    cs.load(cdef, compiled=compiled)
+
+    test = cs.test
+
+    t = test(b"\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0A\x00\x00\x00")
+    assert t.arr == [255, 0, 0, 10]

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -238,6 +238,10 @@ def test_enum_anonymous(compiled):
     assert cs.GREEN == 2
     assert cs.BLUE == 3
 
+    assert cs.RED.name == "RED"
+    assert cs.RED.value == 1
+    assert repr(cs.RED) == "<RED: 1>"
+
 
 def test_enum_anonymous_struct(compiled):
     cdef = """

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -106,3 +106,44 @@ def test_flag_read(compiled):
     assert str(obj.c16) == "Test16.B|A"
 
     assert obj.dumps() == buf
+
+
+def test_flag_anonymous(compiled):
+    cdef = """
+    flag : uint16 {
+          A,
+          B,
+          C,
+    };
+    """
+    cs = cstruct.cstruct()
+    cs.load(cdef, compiled=compiled)
+
+    assert cs.A == 1
+    assert cs.B == 2
+    assert cs.C == 4
+
+    assert cs.A.name == "A"
+    assert cs.A.value == 1
+    assert repr(cs.A) == "<A: 1>"
+
+    assert repr(cs.A | cs.B) == "<B|A: 3>"
+
+
+def test_flag_anonymous_struct(compiled):
+    cdef = """
+    flag : uint32 {
+          nElements = 4
+    };
+
+    struct test {
+        uint32  arr[nElements];
+    };
+    """
+    cs = cstruct.cstruct()
+    cs.load(cdef, compiled=compiled)
+
+    test = cs.test
+
+    t = test(b"\xff\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0A\x00\x00\x00")
+    assert t.arr == [255, 0, 0, 10]


### PR DESCRIPTION
Add support for anonymous enums (https://github.com/fox-it/dissect.cstruct/issues/30). Anonymous enums are treated as top-level defines.

Changed the tokenizer to make the name inside an enum optional.

`r"(?P<enumtype>enum|flag)\s+(?P<name>[^\s:{]+)?\s*(:\s"`

If the enum does not contain a name and the enumtype equals enum we add the key and values of the enum to the consts dictionary.
One thing that I think is now possible is the following
```
flag {
    a,
    b,
    c
}
```
Not sure what the behavior of an anonymous flag should be. If not allowed the only change should be to throw an error if `enumtype == flag and not d["name"]`

Added some tests as well