### PR TITLE
Add support for real-time updating of union  (v4)

### DIFF
--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -66,7 +66,7 @@ class Compiler:
             return structure
 
         try:
-            structure._read = self.compile_read(structure.fields, structure.__name__, structure.__align__)
+            structure._read = self.compile_read(structure.__fields__, structure.__name__, structure.__align__)
             structure.__compiled__ = True
         except Exception as e:
             # Silently ignore, we didn't compile unfortunately

--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -66,7 +66,7 @@ class Compiler:
             return structure
 
         try:
-            structure._read = self.compile_read(structure.fields, structure.__name__, structure.align)
+            structure._read = self.compile_read(structure.fields, structure.__name__, structure.__align__)
             structure.__compiled__ = True
         except Exception as e:
             # Silently ignore, we didn't compile unfortunately
@@ -218,19 +218,11 @@ class ReadSourceGenerator:
             yield f"stream.seek(-stream.tell() & (cls.alignment - 1), {io.SEEK_CUR})"
 
     def _generate_structure(self, field: Field) -> Iterator[str]:
-        if field.type.anonymous:
-            template = f"""
-            _s = stream.tell()
-            _v = {self._map_field(field)}._read(stream, context=r)
-            r.update(_v._values)
-            s.update(_v._sizes)
-            """
-        else:
-            template = f"""
-            _s = stream.tell()
-            r["{field.name}"] = {self._map_field(field)}._read(stream, context=r)
-            s["{field.name}"] = stream.tell() - _s
-            """
+        template = f"""
+        _s = stream.tell()
+        r["{field.name}"] = {self._map_field(field)}._read(stream, context=r)
+        s["{field.name}"] = stream.tell() - _s
+        """
 
         yield dedent(template)
 

--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -193,7 +193,7 @@ class cstruct:
         raise AttributeError(f"Invalid attribute: {attr}")
 
     def _next_anonymous(self) -> str:
-        name = f"anonymous_{self._anonymous_count}"
+        name = f"__anonymous_{self._anonymous_count}__"
         self._anonymous_count += 1
         return name
 
@@ -373,8 +373,8 @@ class cstruct:
             None,
             attrs={
                 "fields": fields,
-                "align": align,
-                "anonymous": anonymous,
+                "__align__": align,
+                "__anonymous__": anonymous,
             },
         )
 

--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -297,7 +297,13 @@ class cstruct:
         raise ResolveError(f"Recursion limit exceeded while resolving type {name}")
 
     def _make_type(
-        self, name: str, bases: Iterator[object], size: int, *, alignment: int = None, attrs: dict[str, Any] = None
+        self,
+        name: str,
+        bases: Iterator[object],
+        size: Optional[int],
+        *,
+        alignment: int = None,
+        attrs: dict[str, Any] = None,
     ) -> type[BaseType]:
         attrs = attrs or {}
         attrs.update(
@@ -387,7 +393,7 @@ class cstruct:
 def ctypes(structure: Structure) -> _ctypes.Structure:
     """Create ctypes structures from cstruct structures."""
     fields = []
-    for field in structure.fields:
+    for field in structure.__fields__:
         t = ctypes_type(field.type)
         fields.append((field.name, t))
 

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -219,7 +219,7 @@ class TokenParser(Parser):
             if self.compiled and "nocompile" not in tokens.flags:
                 st = compiler.compile(st)
         else:
-            st.fields.extend(fields)
+            st.__fields__.extend(fields)
             st.commit()
 
         # This is pretty dirty

--- a/dissect/cstruct/types/base.py
+++ b/dissect/cstruct/types/base.py
@@ -17,9 +17,13 @@ class MetaType(type):
     """Base metaclass for cstruct type classes."""
 
     cs: cstruct
-    size: int
+    """The cstruct instance this type class belongs to."""
+    size: Optional[int]
+    """The size of the type in bytes. Can be ``None`` for dynamic sized types."""
     dynamic: bool
+    """Whether or not the type is dynamically sized."""
     alignment: int
+    """The alignment of the type in bytes."""
 
     def __call__(cls, *args, **kwargs) -> Union[MetaType, BaseType]:
         """Adds support for ``TypeClass(bytes | file-like object)`` parsing syntax."""

--- a/dissect/cstruct/types/enum.py
+++ b/dissect/cstruct/types/enum.py
@@ -15,13 +15,16 @@ class EnumMetaType(EnumMeta, MetaType):
 
     def __call__(
         cls,
-        value: Union[cstruct, int, BinaryIO, bytes],
+        value: Union[cstruct, int, BinaryIO, bytes] = None,
         name: Optional[str] = None,
         type_: Optional[MetaType] = None,
         *args,
         **kwargs,
     ):
         if name is None:
+            if value is None:
+                value = cls.type()
+
             if not isinstance(value, int):
                 # value is a parsable value
                 value = cls.type(value)

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -535,7 +535,7 @@ class Union(Structure, metaclass=UnionMetaType):
         object.__setattr__(self, "_sizes", sizes)
 
     def _proxify(self) -> None:
-        def _proxy_structure(value: Structure) -> UnionProxy:
+        def _proxy_structure(value: Structure) -> None:
             for field in value.__class__.__fields__:
                 if issubclass(field.type, Structure):
                     nested_value = getattr(value, field.name)

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -534,7 +534,7 @@ class Union(Structure, metaclass=UnionMetaType):
         object.__setattr__(self, "_values", result)
         object.__setattr__(self, "_sizes", sizes)
 
-    def _proxify(self) -> UnionProxy:
+    def _proxify(self) -> None:
         def _proxy_structure(value: Structure) -> UnionProxy:
             for field in value.__class__.__fields__:
                 if issubclass(field.type, Structure):

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import io
 from contextlib import contextmanager
 from functools import lru_cache
+from operator import attrgetter
 from textwrap import dedent
 from types import FunctionType
-from typing import Any, BinaryIO, ContextManager, Optional
+from typing import Any, BinaryIO, Callable, ContextManager, Optional
 
 from dissect.cstruct.bitbuffer import BitBuffer
 from dissect.cstruct.types.base import BaseType, MetaType
@@ -15,7 +16,7 @@ from dissect.cstruct.types.enum import EnumMetaType
 class Field:
     """Structure field."""
 
-    def __init__(self, name: str, type_: BaseType, bits: int = None, offset: int = None):
+    def __init__(self, name: str, type_: MetaType, bits: int = None, offset: int = None):
         self.name = name
         self.type = type_
         self.bits = bits
@@ -32,10 +33,11 @@ class StructureMetaType(MetaType):
 
     # TODO: resolve field types in _update_fields, remove resolves elsewhere?
 
-    anonymous: bool
-    align: bool
     fields: list[Field]
     lookup: dict[str, Field]
+
+    __anonymous__: bool
+    __align__: bool
     __lookup__: dict[str, Field]
     __updating__ = False
     __compiled__ = False
@@ -56,6 +58,12 @@ class StructureMetaType(MetaType):
         ):
             # Shortcut for single char/bytes type
             return type.__call__(cls, *args, **kwargs)
+        elif not args and not kwargs:
+            obj = cls(**{field.name: field.type() for field in cls.fields})
+            object.__setattr__(obj, "_values", {})
+            object.__setattr__(obj, "_sizes", {})
+            return obj
+
         return super().__call__(*args, **kwargs)
 
     def _update_fields(
@@ -65,11 +73,18 @@ class StructureMetaType(MetaType):
 
         lookup = {}
         raw_lookup = {}
+        init_names = []
+        field_names = []
         for field in fields:
             if field.name in lookup and field.name != "_":
                 raise ValueError(f"Duplicate field name: {field.name}")
 
-            if isinstance(field.type, StructureMetaType) and field.type.anonymous:
+            if isinstance(field.type, StructureMetaType) and field.type.__anonymous__:
+                for anon_field in field.type.lookup.values():
+                    # TODO: set setting anonymous field
+                    attr = f"{field.name}.{anon_field.name}"
+                    classdict[anon_field.name] = property(attrgetter(attr), attrsetter(attr))
+
                 lookup.update(field.type.lookup)
             else:
                 lookup[field.name] = field
@@ -78,16 +93,20 @@ class StructureMetaType(MetaType):
 
         num_fields = len(lookup)
         field_names = lookup.keys()
+        init_names = raw_lookup.keys()
         classdict["fields"] = fields
         classdict["lookup"] = lookup
         classdict["__lookup__"] = raw_lookup
-        classdict["__init__"] = _patch_args_and_attributes(_make__init__(num_fields), field_names)
         classdict["__bool__"] = _patch_attributes(_make__bool__(num_fields), field_names, 1)
 
-        if issubclass(cls, UnionMetaType):
+        if issubclass(cls, UnionMetaType) or isinstance(cls, UnionMetaType):
+            classdict["__init__"] = _patch_setattr_args_and_attributes(
+                _make_setattr__init__(len(init_names)), init_names
+            )
             # Not a great way to do this but it works for now
             classdict["__eq__"] = Union.__eq__
         else:
+            classdict["__init__"] = _patch_args_and_attributes(_make__init__(len(init_names)), init_names)
             classdict["__eq__"] = _patch_attributes(_make__eq__(num_fields), field_names, 1)
 
         # If we're calling this as a class method or a function on the metaclass
@@ -101,13 +120,13 @@ class StructureMetaType(MetaType):
             from dissect.cstruct import compiler
 
             try:
-                classdict["_read"] = compiler.Compiler(cls.cs).compile_read(fields, cls.__name__, align=cls.align)
-
+                classdict["_read"] = compiler.Compiler(cls.cs).compile_read(fields, cls.__name__, align=cls.__align__)
                 classdict["__compiled__"] = True
             except Exception:
                 # Revert _read to the slower loop based method
                 classdict["_read"] = classmethod(StructureMetaType._read)
                 classdict["__compiled__"] = False
+
         # TODO: compile _write
         # TODO: generate cached_property for lazy reading
 
@@ -220,7 +239,7 @@ class StructureMetaType(MetaType):
                 offset = struct_start + field.offset
                 stream.seek(offset)
 
-            if cls.align and field.offset is None:
+            if cls.__align__ and field.offset is None:
                 # Previous field was dynamically sized and we need to align
                 offset += -offset & (field.alignment - 1)
                 stream.seek(offset)
@@ -239,15 +258,11 @@ class StructureMetaType(MetaType):
 
             value = field_type._read(stream, result)
 
-            if isinstance(field_type, StructureMetaType) and field_type.anonymous:
-                sizes.update(value._sizes)
-                result.update(value._values)
-            else:
-                if field.name:
-                    sizes[field.name] = stream.tell() - offset
-                    result[field.name] = value
+            if field.name:
+                sizes[field.name] = stream.tell() - offset
+                result[field.name] = value
 
-        if cls.align:
+        if cls.__align__:
             # Align the stream
             stream.seek(-stream.tell() & (cls.alignment - 1), io.SEEK_CUR)
 
@@ -290,7 +305,7 @@ class StructureMetaType(MetaType):
                 stream.write(b"\x00" * (struct_start + field.offset - offset))
                 offset = struct_start + field.offset
 
-            if cls.align and field.offset is None:
+            if cls.__align__ and field.offset is None:
                 is_bitbuffer_boundary = bit_buffer._type and (
                     bit_buffer._remaining == 0 or bit_buffer._type != field_type
                 )
@@ -310,16 +325,13 @@ class StructureMetaType(MetaType):
                 else:
                     bit_buffer.write(field_type, value, field.bits)
             else:
-                if isinstance(field_type, StructureMetaType) and field_type.anonymous:
-                    field_type._write(stream, data)
-                else:
-                    field_type._write(stream, value)
+                field_type._write(stream, value)
                 num += stream.tell() - offset
 
         if bit_buffer._type is not None:
             bit_buffer.flush()
 
-        if cls.align:
+        if cls.__align__:
             # Align the stream
             stream.write(b"\x00" * (-stream.tell() & (cls.alignment - 1)))
 
@@ -342,7 +354,7 @@ class StructureMetaType(MetaType):
             cls.__updating__ = False
 
     def commit(cls) -> None:
-        classdict = cls._update_fields(cls.fields, cls.align)
+        classdict = cls._update_fields(cls.fields, cls.__align__)
 
         for key, value in classdict.items():
             setattr(cls, key, value)
@@ -363,9 +375,26 @@ class Structure(BaseType, metaclass=StructureMetaType):
     def __getitem__(self, item: str) -> Any:
         return getattr(self, item)
 
+    def __repr__(self) -> str:
+        values = " ".join(
+            [
+                f"{k}={hex(getattr(self, k)) if issubclass(f.type, int) else repr(getattr(self, k))}"
+                for k, f in self.__class__.lookup.items()
+            ]
+        )
+        return f"<{self.__class__.__name__} {values}>"
+
 
 class UnionMetaType(StructureMetaType):
     """Base metaclass for cstruct union type classes."""
+
+    def __call__(cls, *args, **kwargs) -> Union:
+        obj = super().__call__(*args, **kwargs)
+        if kwargs:
+            # Calling with kwargs means we are initializing with values
+            # Proxify all values
+            obj._proxify()
+        return obj
 
     def _calculate_size_and_offsets(cls, fields: list[Field], align: bool = False) -> tuple[Optional[int], int]:
         size = 0
@@ -386,7 +415,7 @@ class UnionMetaType(StructureMetaType):
 
         return size, alignment
 
-    def _read(cls, stream: BinaryIO, context: dict[str, Any] = None) -> Union:
+    def _read_fields(cls, stream: BinaryIO, context: dict[str, Any] = None) -> tuple[dict[str, Any], dict[str, int]]:
         result = {}
         sizes = {}
 
@@ -407,16 +436,31 @@ class UnionMetaType(StructureMetaType):
             buf.seek(offset + start)
             value = field_type._read(buf, result)
 
-            if isinstance(field_type, StructureMetaType) and field_type.anonymous:
-                sizes.update(value._sizes)
-                result.update(value._values)
-            else:
-                sizes[field.name] = buf.tell() - start
-                result[field.name] = value
+            sizes[field.name] = buf.tell() - start
+            result[field.name] = value
 
-        obj = cls(**result)
-        obj._sizes = sizes
-        obj._values = result
+        return result, sizes
+
+    def _read(cls, stream: BinaryIO, context: dict[str, Any] = None) -> Union:
+        if cls.size is None:
+            start = stream.tell()
+            result, sizes = cls._read_fields(stream, context)
+            size = stream.tell() - start
+            stream.seek(start)
+            buf = stream.read(size)
+        else:
+            result = {}
+            sizes = {}
+            buf = stream.read(cls.size)
+
+        obj: Union = cls(**result)
+        object.__setattr__(obj, "_values", result)
+        object.__setattr__(obj, "_sizes", sizes)
+        object.__setattr__(obj, "_buf", buf)
+
+        if cls.size is not None:
+            obj._update()
+
         return obj
 
     def _write(cls, stream: BinaryIO, data: Union) -> int:
@@ -429,7 +473,7 @@ class UnionMetaType(StructureMetaType):
 
         # Try to write by largest field
         for field in fields:
-            if isinstance(field.type, StructureMetaType) and field.type.anonymous:
+            if isinstance(field.type, StructureMetaType) and field.type.__anonymous__:
                 # Prefer to write regular fields initially
                 anonymous_struct = field.type
                 continue
@@ -456,8 +500,91 @@ class UnionMetaType(StructureMetaType):
 class Union(Structure, metaclass=UnionMetaType):
     """Base class for cstruct union type classes."""
 
+    _buf: bytes
+
     def __eq__(self, other: Any) -> bool:
         return self.__class__ is other.__class__ and bytes(self) == bytes(other)
+
+    def __setattr__(self, attr: str, value: Any) -> None:
+        if self.__class__.dynamic:
+            raise NotImplementedError("Modifying a dynamic union is not yet supported")
+
+        super().__setattr__(attr, value)
+        self._rebuild(attr)
+
+    def _rebuild(self, attr: str) -> None:
+        if (cur_buf := getattr(self, "_buf", None)) is None:
+            cur_buf = b"\x00" * self.__class__.size
+
+        buf = io.BytesIO(cur_buf)
+        field = self.__class__.lookup[attr]
+        if field.offset:
+            buf.seek(field.offset)
+        field.type._write(buf, getattr(self, attr))
+
+        object.__setattr__(self, "_buf", buf.getvalue())
+        self._update()
+
+    def _update(self) -> None:
+        result, sizes = self.__class__._read_fields(io.BytesIO(self._buf))
+        self.__dict__.update(result)
+        object.__setattr__(self, "_values", result)
+        object.__setattr__(self, "_sizes", sizes)
+
+    def _proxify(self) -> UnionProxy:
+        def _proxy_structure(value: Structure) -> UnionProxy:
+            for field in value.__class__.fields:
+                if issubclass(field.type, Structure):
+                    nested_value = getattr(value, field.name)
+                    proxy = UnionProxy(self, field.name, nested_value)
+                    object.__setattr__(value, field.name, proxy)
+                    if hasattr(value, "_values"):
+                        value._values[field.name] = proxy
+                    _proxy_structure(nested_value)
+
+        _proxy_structure(self)
+
+
+class UnionProxy:
+    __union__: Union
+    __attr__: str
+    __target__: Structure
+
+    def __init__(self, union: Union, attr: str, target: Structure):
+        object.__setattr__(self, "__union__", union)
+        object.__setattr__(self, "__attr__", attr)
+        object.__setattr__(self, "__target__", target)
+
+    def __len__(self) -> int:
+        return len(self.__target__.dumps())
+
+    def __bytes__(self) -> bytes:
+        return self.__target__.dumps()
+
+    def __getitem__(self, item: str) -> Any:
+        return getattr(self.__target__, item)
+
+    def __repr__(self) -> str:
+        return repr(self.__target__)
+
+    def __getattr__(self, attr: str) -> Any:
+        return getattr(self.__target__, attr)
+
+    def __setattr__(self, attr: str, value: Any) -> None:
+        setattr(self.__target__, attr, value)
+        self.__union__._rebuild(self.__attr__)
+
+
+def attrsetter(path: str) -> Callable[[Any], Any]:
+    path, _, attr = path.rpartition(".")
+    path = path.split(".")
+
+    def _func(obj: Any, value: Any) -> Any:
+        for name in path:
+            obj = getattr(obj, name)
+        setattr(obj, attr, value)
+
+    return _func
 
 
 def _codegen(func: FunctionType) -> FunctionType:
@@ -482,6 +609,17 @@ def _patch_args_and_attributes(func: FunctionType, fields: list[str], start: int
     )
 
 
+def _patch_setattr_args_and_attributes(func: FunctionType, fields: list[str], start: int = 0) -> FunctionType:
+    return type(func)(
+        func.__code__.replace(
+            co_consts=(None, *fields),
+            co_varnames=("self", *fields),
+        ),
+        func.__globals__,
+        argdefs=func.__defaults__,
+    )
+
+
 def _patch_attributes(func: FunctionType, fields: list[str], start: int = 0) -> FunctionType:
     return type(func)(
         func.__code__.replace(co_names=(*func.__code__.co_names[:start], *fields)),
@@ -492,10 +630,19 @@ def _patch_attributes(func: FunctionType, fields: list[str], start: int = 0) -> 
 @_codegen
 def _make__init__(fields: list[str]) -> str:
     field_args = ", ".join(f"{field} = None" for field in fields)
-    field_init = "\n".join(f" self.{name} = {name}" for name in fields) or " pass"
+    field_init = "\n".join(f" self.{name} = {name}" for name in fields)
 
     code = f"def __init__(self{', ' + field_args if field_args else ''}):\n"
-    return code + field_init
+    return code + (field_init or " pass")
+
+
+@_codegen
+def _make_setattr__init__(fields: list[str]) -> str:
+    field_args = ", ".join(f"{field} = None" for field in fields)
+    field_init = "\n".join(f" object.__setattr__(self, {name!r}, {name})" for name in fields)
+
+    code = f"def __init__(self{', ' + field_args if field_args else ''}):\n"
+    return code + (field_init or " pass")
 
 
 @_codegen

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -81,7 +81,6 @@ class StructureMetaType(MetaType):
 
             if isinstance(field.type, StructureMetaType) and field.type.__anonymous__:
                 for anon_field in field.type.lookup.values():
-                    # TODO: set setting anonymous field
                     attr = f"{field.name}.{anon_field.name}"
                     classdict[anon_field.name] = property(attrgetter(attr), attrsetter(attr))
 

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -537,8 +537,6 @@ class Union(Structure, metaclass=UnionMetaType):
                     nested_value = getattr(value, field.name)
                     proxy = UnionProxy(self, field.name, nested_value)
                     object.__setattr__(value, field.name, proxy)
-                    if hasattr(value, "_values"):
-                        value._values[field.name] = proxy
                     _proxy_structure(nested_value)
 
         _proxy_structure(self)

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -137,7 +137,7 @@ def _dumpstruct(
     ci = 0
     out = [f"struct {structure.__class__.__name__}:"]
     foreground, background = None, None
-    for field in structure.__class__.fields:
+    for field in structure.__class__.__fields__:
         if getattr(field.type, "anonymous", False):
             continue
 

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -20,7 +20,7 @@ def test_align_struct(cs: cstruct, compiled: bool):
     assert verify_compiled(cs.test, compiled)
 
     fields = cs.test.fields
-    assert cs.test.align
+    assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 32
     assert fields[0].offset == 0x00
@@ -55,7 +55,7 @@ def test_align_union(cs: cstruct):
     """
     cs.load(cdef, align=True)
 
-    assert cs.test.align
+    assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 8
 
@@ -88,7 +88,7 @@ def test_align_array(cs: cstruct, compiled: bool):
     assert verify_compiled(cs.test, compiled)
 
     fields = cs.test.fields
-    assert cs.test.align
+    assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 64
     assert fields[0].offset == 0x00
@@ -133,7 +133,7 @@ def test_align_struct_array(cs: cstruct, compiled: bool):
     assert verify_compiled(cs.array, compiled)
 
     fields = cs.test.fields
-    assert cs.test.align
+    assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 16
     assert fields[0].offset == 0x00
@@ -299,7 +299,7 @@ def test_align_pointer(cs: cstruct, compiled: bool):
     assert verify_compiled(cs.test, compiled)
 
     fields = cs.test.fields
-    assert cs.test.align
+    assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 24
     assert fields[0].offset == 0x00

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -19,7 +19,7 @@ def test_align_struct(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 32
@@ -41,7 +41,7 @@ def test_align_struct(cs: cstruct, compiled: bool):
     assert fh.tell() == 32
 
     for name, value in obj._values.items():
-        assert cs.test.lookup[name].offset == value
+        assert cs.test.fields[name].offset == value
 
     assert obj.dumps() == buf
 
@@ -87,7 +87,7 @@ def test_align_array(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 64
@@ -132,7 +132,7 @@ def test_align_struct_array(cs: cstruct, compiled: bool):
     assert verify_compiled(cs.test, compiled)
     assert verify_compiled(cs.array, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 16
@@ -177,7 +177,7 @@ def test_align_dynamic(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert fields[0].offset == 0
     assert fields[1].offset == 2
     assert fields[2].offset is None
@@ -221,7 +221,7 @@ def test_align_nested_struct(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert fields[0].offset == 0x00
     assert fields[1].offset == 0x08
     assert fields[2].offset == 0x18
@@ -257,7 +257,7 @@ def test_align_bitfield(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert fields[0].offset == 0x00
     assert fields[1].offset is None
     assert fields[2].offset == 0x08
@@ -298,7 +298,7 @@ def test_align_pointer(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 24

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -493,8 +493,8 @@ def test_array_class_name(cs: cstruct):
     """
     cs.load(cdef)
 
-    assert cs.test.fields[0].type.__name__ == "uint8[2]"
-    assert cs.test2.fields[1].type.__name__ == "uint8[a + 1]"
+    assert cs.test.__fields__[0].type.__name__ == "uint8[2]"
+    assert cs.test2.__fields__[1].type.__name__ == "uint8[a + 1]"
 
 
 def test_size_and_aligment(cs: cstruct):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -322,8 +322,8 @@ def test_multipart_type_name(cs: cstruct):
     cs.load(cdef)
 
     assert cs.TestEnum.type == cs.resolve("unsigned int")
-    assert cs.test.fields[0].type == cs.resolve("unsigned int")
-    assert cs.test.fields[1].type == cs.resolve("unsigned long long")
+    assert cs.test.__fields__[0].type == cs.resolve("unsigned int")
+    assert cs.test.__fields__[1].type == cs.resolve("unsigned long long")
 
     with pytest.raises(ResolveError) as exc:
         cdef = """

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -259,7 +259,7 @@ def test_generate_packed_read_offsets(cs: cstruct):
 
 def test_generate_structure_read(cs: cstruct):
     mock_type = Mock()
-    mock_type.anonymous = False
+    mock_type.__anonymous__ = False
 
     field = Field("a", mock_type)
     code = next(compiler.ReadSourceGenerator(cs, [field])._generate_structure(field))
@@ -275,16 +275,15 @@ def test_generate_structure_read(cs: cstruct):
 
 def test_generate_structure_read_anonymous(cs: cstruct):
     mock_type = Mock()
-    mock_type.anonymous = True
+    mock_type.__anonymous__ = True
 
     field = Field("a", mock_type)
     code = next(compiler.ReadSourceGenerator(cs, [field])._generate_structure(field))
 
     expected = """
     _s = stream.tell()
-    _v = _0._read(stream, context=r)
-    r.update(_v._values)
-    s.update(_v._sizes)
+    r["a"] = _0._read(stream, context=r)
+    s["a"] = stream.tell() - _s
     """
 
     assert code == dedent(expected)

--- a/tests/test_types_structure.py
+++ b/tests/test_types_structure.py
@@ -25,8 +25,8 @@ def TestStruct(cs: cstruct) -> type[Structure]:
 def test_structure(TestStruct: type[Structure]):
     assert issubclass(TestStruct, Structure)
     assert len(TestStruct.fields) == 2
-    assert TestStruct.lookup["a"].name == "a"
-    assert TestStruct.lookup["b"].name == "b"
+    assert TestStruct.fields["a"].name == "a"
+    assert TestStruct.fields["b"].name == "b"
 
     assert TestStruct.size == 8
     assert TestStruct.alignment == 4
@@ -222,8 +222,8 @@ def test_structure_definitions(cs: cstruct, compiled: bool):
     assert cs.test.__name__ == "_test"
     assert cs._test.__name__ == "_test"
 
-    assert "a" in cs.test.lookup
-    assert "b" in cs.test.lookup
+    assert "a" in cs.test.fields
+    assert "b" in cs.test.fields
 
     with pytest.raises(ParserError):
         cdef = """
@@ -539,5 +539,5 @@ def test_structure_definition_self(cs: cstruct):
     """
     cs.load(cdef)
 
-    assert issubclass(cs.test.fields[1].type, Pointer)
-    assert cs.test.fields[1].type.type is cs.test
+    assert issubclass(cs.test.fields["b"].type, Pointer)
+    assert cs.test.fields["b"].type.type is cs.test

--- a/tests/test_types_union.py
+++ b/tests/test_types_union.py
@@ -20,8 +20,8 @@ def TestUnion(cs: cstruct) -> type[Union]:
 def test_union(TestUnion: type[Union]):
     assert issubclass(TestUnion, Union)
     assert len(TestUnion.fields) == 2
-    assert TestUnion.lookup["a"].name == "a"
-    assert TestUnion.lookup["b"].name == "b"
+    assert TestUnion.fields["a"].name == "a"
+    assert TestUnion.fields["b"].name == "b"
 
     assert TestUnion.size == 4
     assert TestUnion.alignment == 4

--- a/tests/test_types_union.py
+++ b/tests/test_types_union.py
@@ -269,3 +269,69 @@ def test_union_definition_dynamic(cs: cstruct):
     assert obj.a.size == 9
     assert obj.a.data == b"aaaaaaaaa"
     assert obj.b == 0x6161616161616109
+
+
+def test_union_update(cs: cstruct):
+    cdef = """
+    union test {
+        uint8   a;
+        uint16  b;
+    };
+    """
+    cs.load(cdef)
+
+    obj = cs.test()
+    obj.a = 1
+    assert obj.b == 1
+    obj.b = 2
+    assert obj.a == 2
+    obj.b = 0xFFFF
+    assert obj.a == 0xFF
+    assert obj.dumps() == b"\xFF\xFF"
+
+
+def test_union_nested_update(cs: cstruct):
+    cdef = """
+    struct test {
+        char magic[4];
+        union {
+            struct {
+                uint32 a;
+                uint32 b;
+            } a;
+            struct {
+                char   b[8];
+            } b;
+        } c;
+    };
+    """
+    cs.load(cdef)
+
+    obj = cs.test()
+    obj.magic = b"1337"
+    obj.c.b.b = b"ABCDEFGH"
+    assert obj.c.a.a == 0x44434241
+    assert obj.c.a.b == 0x48474645
+    assert obj.dumps() == b"1337ABCDEFGH"
+
+
+def test_union_anonymous_update(cs: cstruct):
+    cdef = """
+    typedef struct test
+    {
+        union {
+            uint32 a;
+            struct
+            {
+                char b[3];
+                char c;
+            };
+        };
+        uint32 d;
+    }
+    """
+    cs.load(cdef)
+
+    obj = cs.test()
+    obj.a = 0x41414141
+    assert obj.b == b"AAA"


### PR DESCRIPTION
This mainly adds support for the real-time updating of union members (also when nested deep in structures within the union) as described in https://github.com/fox-it/dissect.cstruct/pull/44 and https://github.com/fox-it/dissect.cstruct/issues/48.

In the process, this also changes some things with how anonymous fields are managed, as well as renaming some structure metadata fields.

Closes #48 and supersedes #44. Obviously depends on #35.