### PR TITLE
Make `Structure.fields` a dictionary

### DIFF
--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -66,7 +66,7 @@ class Compiler:
             return structure
 
         try:
-            structure._read = self.compile_read(structure.fields, structure.__name__, structure.__align__)
+            structure._read = self.compile_read(structure.__fields__, structure.__name__, structure.__align__)
             structure.__compiled__ = True
         except Exception as e:
             # Silently ignore, we didn't compile unfortunately

--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -289,7 +289,13 @@ class cstruct:
         raise ResolveError(f"Recursion limit exceeded while resolving type {name}")
 
     def _make_type(
-        self, name: str, bases: Iterator[object], size: int, *, alignment: int = None, attrs: dict[str, Any] = None
+        self,
+        name: str,
+        bases: Iterator[object],
+        size: Optional[int],
+        *,
+        alignment: int = None,
+        attrs: dict[str, Any] = None,
     ) -> type[BaseType]:
         attrs = attrs or {}
         attrs.update(
@@ -378,7 +384,7 @@ class cstruct:
 def ctypes(structure: Structure) -> _ctypes.Structure:
     """Create ctypes structures from cstruct structures."""
     fields = []
-    for field in structure.fields:
+    for field in structure.__fields__:
         t = ctypes_type(field.type)
         fields.append((field.name, t))
 

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -219,7 +219,7 @@ class TokenParser(Parser):
             if self.compiled and "nocompile" not in tokens.flags:
                 st = compiler.compile(st)
         else:
-            st.fields.extend(fields)
+            st.__fields__.extend(fields)
             st.commit()
 
         # This is pretty dirty

--- a/dissect/cstruct/types/base.py
+++ b/dissect/cstruct/types/base.py
@@ -17,9 +17,13 @@ class MetaType(type):
     """Base metaclass for cstruct type classes."""
 
     cs: cstruct
-    size: int
+    """The cstruct instance this type class belongs to."""
+    size: Optional[int]
+    """The size of the type in bytes. Can be ``None`` for dynamic sized types."""
     dynamic: bool
+    """Whether or not the type is dynamically sized."""
     alignment: int
+    """The alignment of the type in bytes."""
 
     def __call__(cls, *args, **kwargs) -> Union[MetaType, BaseType]:
         """Adds support for ``TypeClass(bytes | file-like object)`` parsing syntax."""

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -137,7 +137,7 @@ def _dumpstruct(
     ci = 0
     out = [f"struct {structure.__class__.__name__}:"]
     foreground, background = None, None
-    for field in structure.__class__.fields:
+    for field in structure.__class__.__fields__:
         if color:
             foreground, background = colors[ci % len(colors)]
             palette.append((structure._sizes[field.name], background))

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -19,7 +19,7 @@ def test_align_struct(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 32
@@ -41,7 +41,7 @@ def test_align_struct(cs: cstruct, compiled: bool):
     assert fh.tell() == 32
 
     for name, value in obj._values.items():
-        assert cs.test.lookup[name].offset == value
+        assert cs.test.fields[name].offset == value
 
     assert obj.dumps() == buf
 
@@ -87,7 +87,7 @@ def test_align_array(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 64
@@ -132,7 +132,7 @@ def test_align_struct_array(cs: cstruct, compiled: bool):
     assert verify_compiled(cs.test, compiled)
     assert verify_compiled(cs.array, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 16
@@ -177,7 +177,7 @@ def test_align_dynamic(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert fields[0].offset == 0
     assert fields[1].offset == 2
     assert fields[2].offset is None
@@ -221,7 +221,7 @@ def test_align_nested_struct(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert fields[0].offset == 0x00
     assert fields[1].offset == 0x08
     assert fields[2].offset == 0x18
@@ -257,7 +257,7 @@ def test_align_bitfield(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert fields[0].offset == 0x00
     assert fields[1].offset is None
     assert fields[2].offset == 0x08
@@ -298,7 +298,7 @@ def test_align_pointer(cs: cstruct, compiled: bool):
 
     assert verify_compiled(cs.test, compiled)
 
-    fields = cs.test.fields
+    fields = cs.test.__fields__
     assert cs.test.__align__
     assert cs.test.alignment == 8
     assert cs.test.size == 24

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -322,8 +322,8 @@ def test_multipart_type_name(cs: cstruct):
     cs.load(cdef)
 
     assert cs.TestEnum.type == cs.resolve("unsigned int")
-    assert cs.test.fields[0].type == cs.resolve("unsigned int")
-    assert cs.test.fields[1].type == cs.resolve("unsigned long long")
+    assert cs.test.__fields__[0].type == cs.resolve("unsigned int")
+    assert cs.test.__fields__[1].type == cs.resolve("unsigned long long")
 
     with pytest.raises(ResolveError) as exc:
         cdef = """

--- a/tests/test_types_structure.py
+++ b/tests/test_types_structure.py
@@ -25,8 +25,8 @@ def TestStruct(cs: cstruct) -> type[Structure]:
 def test_structure(TestStruct: type[Structure]):
     assert issubclass(TestStruct, Structure)
     assert len(TestStruct.fields) == 2
-    assert TestStruct.lookup["a"].name == "a"
-    assert TestStruct.lookup["b"].name == "b"
+    assert TestStruct.fields["a"].name == "a"
+    assert TestStruct.fields["b"].name == "b"
 
     assert TestStruct.size == 8
     assert TestStruct.alignment == 4
@@ -222,8 +222,8 @@ def test_structure_definitions(cs: cstruct, compiled: bool):
     assert cs.test.__name__ == "_test"
     assert cs._test.__name__ == "_test"
 
-    assert "a" in cs.test.lookup
-    assert "b" in cs.test.lookup
+    assert "a" in cs.test.fields
+    assert "b" in cs.test.fields
 
     with pytest.raises(ParserError):
         cdef = """
@@ -539,5 +539,5 @@ def test_structure_definition_self(cs: cstruct):
     """
     cs.load(cdef)
 
-    assert issubclass(cs.test.fields[1].type, Pointer)
-    assert cs.test.fields[1].type.type is cs.test
+    assert issubclass(cs.test.fields["b"].type, Pointer)
+    assert cs.test.fields["b"].type.type is cs.test

--- a/tests/test_types_union.py
+++ b/tests/test_types_union.py
@@ -20,8 +20,8 @@ def TestUnion(cs: cstruct) -> type[Union]:
 def test_union(TestUnion: type[Union]):
     assert issubclass(TestUnion, Union)
     assert len(TestUnion.fields) == 2
-    assert TestUnion.lookup["a"].name == "a"
-    assert TestUnion.lookup["b"].name == "b"
+    assert TestUnion.fields["a"].name == "a"
+    assert TestUnion.fields["b"].name == "b"
 
     assert TestUnion.size == 4
     assert TestUnion.alignment == 4


### PR DESCRIPTION
This PR makes `Structure.fields` a dictionary, rather than a list. A dictionary mapping of fields is generally more useful to end-users, so this change makes that more easily available.

The list of fields is still available at `__fields__` and is still considered the "single source of truth" of the structure contents. Because this change effectively makes `fields` behave exactly like the old `lookup`, I've removed `__lookup__` and moved that into `lookup`.

This PR merges into the union editting v4 PR because it relies on some changes in there.