### PR TITLE
Add LEB128 variable-lengh integer support

### DIFF
--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -29,6 +29,7 @@ from dissect.cstruct.types import (
     Wchar,
     WcharArray,
 )
+from dissect.cstruct.types.leb128 import LEB128
 
 
 class cstruct:
@@ -70,6 +71,9 @@ class cstruct:
             "uint48": self._make_int_type("int48", 6, False, alignment=8),
             "int128": self._make_int_type("int128", 16, True, alignment=16),
             "uint128": self._make_int_type("uint128", 16, False, alignment=16),
+
+            "uleb128": self._make_type('uleb128', (LEB128,), None, alignment=4, attrs={"signed": False}),
+            "ileb128": self._make_type('ileb128', (LEB128,), None, alignment=4, attrs={"signed": True}),
 
             "void": self._make_type("void", (Void,), 0),
 

--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -11,6 +11,7 @@ from dissect.cstruct.exceptions import ResolveError
 from dissect.cstruct.expression import Expression
 from dissect.cstruct.parser import CStyleParser, TokenParser
 from dissect.cstruct.types import (
+    LEB128,
     Array,
     ArrayMetaType,
     BaseType,
@@ -29,7 +30,6 @@ from dissect.cstruct.types import (
     Wchar,
     WcharArray,
 )
-from dissect.cstruct.types.leb128 import LEB128
 
 
 class cstruct:

--- a/dissect/cstruct/types/__init__.py
+++ b/dissect/cstruct/types/__init__.py
@@ -3,6 +3,7 @@ from dissect.cstruct.types.char import Char, CharArray
 from dissect.cstruct.types.enum import Enum
 from dissect.cstruct.types.flag import Flag
 from dissect.cstruct.types.int import Int
+from dissect.cstruct.types.leb128 import LEB128
 from dissect.cstruct.types.packed import Packed
 from dissect.cstruct.types.pointer import Pointer
 from dissect.cstruct.types.structure import Field, Structure, Union
@@ -19,6 +20,7 @@ __all__ = [
     "Field",
     "Flag",
     "Int",
+    "LEB128",
     "MetaType",
     "Packed",
     "Pointer",

--- a/dissect/cstruct/types/leb128.py
+++ b/dissect/cstruct/types/leb128.py
@@ -20,7 +20,7 @@ class LEB128(int, BaseType):
         while True:
             b = stream.read(1)
             if b == b"":
-                raise EOFError("EOF reached, while final LEB128 byte was not yet read.")
+                raise EOFError("EOF reached, while final LEB128 byte was not yet read")
 
             b = ord(b)
             result |= (b & 0x7F) << shift
@@ -50,7 +50,7 @@ class LEB128(int, BaseType):
     def _write(cls, stream: BinaryIO, data: int) -> LEB128:
         # only write negative numbers when in signed mode
         if data < 0 and not cls.signed:
-            raise ValueError("Attempt to encode a negative integer using unsigned LEB128 encoding.")
+            raise ValueError("Attempt to encode a negative integer using unsigned LEB128 encoding")
 
         result = bytearray()
         while True:

--- a/dissect/cstruct/types/leb128.py
+++ b/dissect/cstruct/types/leb128.py
@@ -50,7 +50,7 @@ class LEB128(int, BaseType):
     def _write(cls, stream: BinaryIO, data: int) -> LEB128:
         # only write negative numbers when in signed mode
         if data < 0 and not cls.signed:
-            return 0
+            raise ValueError("Attempt to encode a negative integer using unsigned LEB128 encoding.")
 
         result = bytearray()
         while True:

--- a/dissect/cstruct/types/leb128.py
+++ b/dissect/cstruct/types/leb128.py
@@ -7,7 +7,9 @@ from dissect.cstruct.types.base import BaseType
 
 class LEB128(int, BaseType):
     """Variable-length code compression to store an arbitrarily large integer in a small number of bytes.
-    See https://en.wikipedia.org/wiki/LEB128 for more information and an explanation of the algorithm."""
+
+    See https://en.wikipedia.org/wiki/LEB128 for more information and an explanation of the algorithm.
+    """
 
     signed: bool
 
@@ -16,12 +18,18 @@ class LEB128(int, BaseType):
         result = 0
         shift = 0
         while True:
-            b = ord(stream.read(1))
+            b = stream.read(1)
+            if b == b"":
+                raise EOFError("EOF reached, while final LEB128 byte was not yet read.")
+
+            b = ord(b)
             result |= (b & 0x7F) << shift
             shift += 7
             if (b & 0x80) == 0:
                 break
+
         if cls.signed:
             if b & 0x40 != 0:
                 result |= ~0 << shift
+
         return result

--- a/dissect/cstruct/types/leb128.py
+++ b/dissect/cstruct/types/leb128.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, BinaryIO
+
+from dissect.cstruct.types.base import BaseType
+
+
+class LEB128(int, BaseType):
+    """Variable-length code compression to store an arbitrarily large integer in a small number of bytes.
+    See https://en.wikipedia.org/wiki/LEB128 for more information and an explanation of the algorithm."""
+
+    signed: bool
+
+    @classmethod
+    def _read(cls, stream: BinaryIO, context: dict[str, Any] = None) -> LEB128:
+        result = 0
+        shift = 0
+        while True:
+            b = ord(stream.read(1))
+            result |= (b & 0x7F) << shift
+            shift += 7
+            if (b & 0x80) == 0:
+                break
+        if cls.signed:
+            if b & 0x40 != 0:
+                result |= ~0 << shift
+        return result

--- a/dissect/cstruct/types/leb128.py
+++ b/dissect/cstruct/types/leb128.py
@@ -33,3 +33,15 @@ class LEB128(int, BaseType):
                 result |= ~0 << shift
 
         return result
+
+    @classmethod
+    def _read_0(cls, stream: BinaryIO, context: dict[str, Any] = None) -> LEB128:
+        result = []
+
+        while True:
+            if (value := cls._read(stream, context)) == 0:
+                break
+
+            result.append(value)
+
+        return result

--- a/dissect/cstruct/types/leb128.py
+++ b/dissect/cstruct/types/leb128.py
@@ -47,7 +47,7 @@ class LEB128(int, BaseType):
         return result
 
     @classmethod
-    def _write(cls, stream: BinaryIO, data: int) -> LEB128:
+    def _write(cls, stream: BinaryIO, data: int) -> int:
         # only write negative numbers when in signed mode
         if data < 0 and not cls.signed:
             raise ValueError("Attempt to encode a negative integer using unsigned LEB128 encoding")
@@ -64,8 +64,10 @@ class LEB128(int, BaseType):
                 not cls.signed and data == 0
             ):
                 result.append(byte)
-                stream.write(result)
-                return len(result)
+                break
 
             # Set high-order bit of byte
             result.append(0x80 | byte)
+
+        stream.write(result)
+        return len(result)

--- a/tests/test_types_leb128.py
+++ b/tests/test_types_leb128.py
@@ -1,0 +1,96 @@
+from dissect.cstruct.cstruct import cstruct
+
+
+def test_leb128_unsigned_read(cs: cstruct):
+    assert cs.uleb128(b"\x02") == 2
+    assert cs.uleb128(b"\x8b%") == 4747
+    assert cs.uleb128(b"\xc9\x8f\xb0\x06") == 13371337
+    assert cs.uleb128(b"~") == 126
+    assert cs.uleb128(b"\xf5Z") == 11637
+    assert cs.uleb128(b"\xde\xd6\xcf|") == 261352286
+
+
+def test_leb128_signed_read(cs: cstruct):
+    assert cs.ileb128(b"\x02") == 2
+    assert cs.ileb128(b"\x8b%") == 4747
+    assert cs.ileb128(b"\xc9\x8f\xb0\x06") == 13371337
+    assert cs.ileb128(b"~") == -2
+    assert cs.ileb128(b"\xf5Z") == -4747
+    assert cs.ileb128(b"\xde\xd6\xcf|") == -7083170
+
+
+def test_leb128_struct_unsigned(cs: cstruct, compiled: bool):
+    cdef = """
+    struct test {
+        uleb128 len;
+        char  data[len];
+    };
+    """
+    cs.load(cdef, compiled=compiled)
+
+    buf = b"\xaf\x18"
+    buf += b"A" * 3119
+    obj = cs.test(buf)
+
+    assert obj.len == 3119
+    assert obj.data == (b"A" * 3119)
+    assert len(obj.data) == 3119
+    assert len(buf) == 3119 + 2
+
+
+def test_leb128_nested_struct_unsigned(cs: cstruct, compiled: bool):
+    cdef = """
+    struct entry {
+        uleb128 len;
+        char  data[len];
+        uint32 crc;
+    };
+    struct nested {
+        uleb128  name_len;
+        char     name[name_len];
+        uleb128  n_entries;
+        entry    entries[n_entries];
+    };
+    """
+    cs.load(cdef, compiled=compiled)
+
+    # Dummy file format specifying 300 entries
+    buf = b"\x08Testfile\xac\x02"
+
+    # Each entry has 4 byte data + 4 byte CRC
+    buf += b"\x04AAAABBBB" * 300
+
+    obj = cs.nested(buf)
+
+    assert obj.name_len == 8
+    assert obj.name == b"Testfile"
+    assert obj.n_entries == 300
+
+
+def test_leb128_nested_struct_signed(cs: cstruct, compiled: bool):
+    cdef = """
+    struct entry {
+        ileb128 len;
+        char  data[len];
+        uint32 crc;
+    };
+    struct nested {
+        ileb128  name_len;
+        char     name[name_len];
+        ileb128  n_entries;
+        entry    entries[n_entries];
+    };
+    """
+    cs.load(cdef, compiled=compiled)
+
+    # Dummy file format specifying 300 entries
+    buf = b"\x08Testfile\xac\x02"
+
+    # Each entry has 4 byte data + 4 byte CRC
+    buf += b"\x04AAAABBBB" * 300
+
+    obj = cs.nested(buf)
+
+    assert obj.name_len == 8
+    assert obj.name == b"Testfile"
+    assert obj.n_entries == 300

--- a/tests/test_types_leb128.py
+++ b/tests/test_types_leb128.py
@@ -1,4 +1,12 @@
+import pytest
+
 from dissect.cstruct.cstruct import cstruct
+
+
+def test_leb128_unsigned_read_EOF(cs: cstruct):
+    with pytest.raises(EOFError) as ex:
+        cs.uleb128(b"\x8b")
+    assert str(ex.value) == "EOF reached, while final LEB128 byte was not yet read."
 
 
 def test_leb128_unsigned_read(cs: cstruct):
@@ -19,14 +27,14 @@ def test_leb128_signed_read(cs: cstruct):
     assert cs.ileb128(b"\xde\xd6\xcf|") == -7083170
 
 
-def test_leb128_struct_unsigned(cs: cstruct, compiled: bool):
+def test_leb128_struct_unsigned(cs: cstruct):
     cdef = """
     struct test {
         uleb128 len;
         char  data[len];
     };
     """
-    cs.load(cdef, compiled=compiled)
+    cs.load(cdef)
 
     buf = b"\xaf\x18"
     buf += b"A" * 3119
@@ -38,7 +46,7 @@ def test_leb128_struct_unsigned(cs: cstruct, compiled: bool):
     assert len(buf) == 3119 + 2
 
 
-def test_leb128_nested_struct_unsigned(cs: cstruct, compiled: bool):
+def test_leb128_nested_struct_unsigned(cs: cstruct):
     cdef = """
     struct entry {
         uleb128 len;
@@ -52,7 +60,7 @@ def test_leb128_nested_struct_unsigned(cs: cstruct, compiled: bool):
         entry    entries[n_entries];
     };
     """
-    cs.load(cdef, compiled=compiled)
+    cs.load(cdef)
 
     # Dummy file format specifying 300 entries
     buf = b"\x08Testfile\xac\x02"
@@ -67,7 +75,7 @@ def test_leb128_nested_struct_unsigned(cs: cstruct, compiled: bool):
     assert obj.n_entries == 300
 
 
-def test_leb128_nested_struct_signed(cs: cstruct, compiled: bool):
+def test_leb128_nested_struct_signed(cs: cstruct):
     cdef = """
     struct entry {
         ileb128 len;
@@ -81,7 +89,7 @@ def test_leb128_nested_struct_signed(cs: cstruct, compiled: bool):
         entry    entries[n_entries];
     };
     """
-    cs.load(cdef, compiled=compiled)
+    cs.load(cdef)
 
     # Dummy file format specifying 300 entries
     buf = b"\x08Testfile\xac\x02"

--- a/tests/test_types_leb128.py
+++ b/tests/test_types_leb128.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 
 from dissect.cstruct.cstruct import cstruct
@@ -159,3 +161,17 @@ def test_leb128_write_negatives(cs: cstruct):
     with pytest.raises(ValueError, match="Attempt to encode a negative integer using unsigned LEB128 encoding"):
         cs.uleb128(-2).dumps()
     assert cs.ileb128(-2).dumps() == b"\x7e"
+
+
+def test_leb128_unsigned_write_amount_written(cs: cstruct):
+    out1 = io.BytesIO()
+    bytes_written1 = cs.uleb128(2).write(out1)
+    assert bytes_written1 == out1.tell()
+
+    out2 = io.BytesIO()
+    bytes_written2 = cs.uleb128(4747).write(out2)
+    assert bytes_written2 == out2.tell()
+
+    out3 = io.BytesIO()
+    bytes_written3 = cs.uleb128(13371337).write(out3)
+    assert bytes_written3 == out3.tell()

--- a/tests/test_types_leb128.py
+++ b/tests/test_types_leb128.py
@@ -136,3 +136,21 @@ def test_leb128_nested_struct_signed(cs: cstruct):
     assert obj.name_len == 8
     assert obj.name == b"Testfile"
     assert obj.n_entries == 300
+
+
+def test_leb128_unsigned_write(cs: cstruct):
+    assert cs.uleb128(2).dumps() == b"\x02"
+    assert cs.uleb128(4747).dumps() == b"\x8b%"
+    assert cs.uleb128(13371337).dumps() == b"\xc9\x8f\xb0\x06"
+    assert cs.uleb128(126).dumps() == b"~"
+    assert cs.uleb128(11637).dumps() == b"\xf5Z"
+    assert cs.uleb128(261352286).dumps() == b"\xde\xd6\xcf|"
+
+
+def test_leb128_signed_write(cs: cstruct):
+    assert cs.ileb128(2).dumps() == b"\x02"
+    assert cs.ileb128(4747).dumps() == b"\x8b%"
+    assert cs.ileb128(13371337).dumps() == b"\xc9\x8f\xb0\x06"
+    assert cs.ileb128(-2).dumps() == b"~"
+    assert cs.ileb128(-4747).dumps() == b"\xf5Z"
+    assert cs.ileb128(-7083170).dumps() == b"\xde\xd6\xcf|"

--- a/tests/test_types_leb128.py
+++ b/tests/test_types_leb128.py
@@ -46,6 +46,40 @@ def test_leb128_struct_unsigned(cs: cstruct):
     assert len(buf) == 3119 + 2
 
 
+def test_leb128_struct_unsigned_zero(cs: cstruct):
+    cdef = """
+    struct test {
+        uleb128 numbers[];
+    };
+    """
+    cs.load(cdef)
+
+    buf = b"\xaf\x18\x8b%\xc9\x8f\xb0\x06\x00"
+    obj = cs.test(buf)
+
+    assert len(obj.numbers) == 3
+    assert obj.numbers[0] == 3119
+    assert obj.numbers[1] == 4747
+    assert obj.numbers[2] == 13371337
+
+
+def test_leb128_struct_signed_zero(cs: cstruct):
+    cdef = """
+    struct test {
+        ileb128 numbers[];
+    };
+    """
+    cs.load(cdef)
+
+    buf = b"\xaf\x18\xf5Z\xde\xd6\xcf|\x00"
+    obj = cs.test(buf)
+
+    assert len(obj.numbers) == 3
+    assert obj.numbers[0] == 3119
+    assert obj.numbers[1] == -4747
+    assert obj.numbers[2] == -7083170
+
+
 def test_leb128_nested_struct_unsigned(cs: cstruct):
     cdef = """
     struct entry {

--- a/tests/test_types_leb128.py
+++ b/tests/test_types_leb128.py
@@ -154,3 +154,10 @@ def test_leb128_signed_write(cs: cstruct):
     assert cs.ileb128(-2).dumps() == b"~"
     assert cs.ileb128(-4747).dumps() == b"\xf5Z"
     assert cs.ileb128(-7083170).dumps() == b"\xde\xd6\xcf|"
+
+
+def test_leb128_write_negatives(cs: cstruct):
+    with pytest.raises(ValueError) as ex:
+        cs.uleb128(-2).dumps()
+    assert str(ex.value) == "Attempt to encode a negative integer using unsigned LEB128 encoding."
+    assert cs.ileb128(-2).dumps() == b"~"


### PR DESCRIPTION
During the development of a `dissect.target` plugin for parsing Windows Notepad tabs (which will be submitted soon as well), I stumbled upon a variable-length integer encoding scheme that was not yet present in dissect. All is well explained on Wikipedia: https://en.wikipedia.org/wiki/LEB128. This implementation is valid for both signed- and unsigned LEB128 integers, the Wikipedia pseudo-code and some reference implementations on the internet were used to check the code.

Targeting the `refactor-v4`  for now, so that it can hopefully be shipped with the next major release!