### PR TITLE
Add support for array and pointer typedefs

### DIFF
--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -169,7 +169,7 @@ class TokenParser(Parser):
         for name in names:
             type_, name, bits = self._parse_field_type(type_, name)
             if bits is not None:
-                raise ParserError(f"line {self._lineno(tokens.next)}: typedefs cannot have bitfields")
+                raise ParserError(f"line {self._lineno(tokens.previous)}: typedefs cannot have bitfields")
             self.cstruct.addtype(name, type_)
 
     def _struct(self, tokens: TokenConsumer, register: bool = False) -> None:
@@ -581,6 +581,7 @@ class TokenConsumer:
     def __init__(self, tokens: List[Token]):
         self.tokens = tokens
         self.flags = []
+        self.previous = None
 
     def __contains__(self, token) -> bool:
         return token in self.tokens
@@ -599,7 +600,8 @@ class TokenConsumer:
             return None
 
     def consume(self) -> Token:
-        return self.tokens.pop(0)
+        self.previous = self.tokens.pop(0)
+        return self.previous
 
     def reset_flags(self) -> None:
         self.flags = []

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -2,12 +2,21 @@ from __future__ import annotations
 
 import ast
 import re
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from dissect.cstruct.compiler import Compiler
 from dissect.cstruct.exceptions import ParserError
 from dissect.cstruct.expression import Expression
-from dissect.cstruct.types import Array, Enum, Field, Flag, Pointer, Structure, Union
+from dissect.cstruct.types import (
+    Array,
+    BaseType,
+    Enum,
+    Field,
+    Flag,
+    Pointer,
+    Structure,
+    Union,
+)
 
 if TYPE_CHECKING:
     from dissect.cstruct import cstruct
@@ -158,6 +167,9 @@ class TokenParser(Parser):
 
         names = self._names(tokens)
         for name in names:
+            type_, name, bits = self._parse_field_type(type_, name)
+            if bits is not None:
+                raise ParserError(f"line {self._lineno(tokens.next)}: typedefs cannot have bitfields")
             self.cstruct.addtype(name, type_)
 
     def _struct(self, tokens: TokenConsumer, register: bool = False) -> None:
@@ -236,9 +248,15 @@ class TokenParser(Parser):
             raise ParserError(f"line {self._lineno(tokens.next)}: expected name")
         nametok = tokens.consume()
 
+        type_, name, bits = self._parse_field_type(type_, nametok.value)
+
+        tokens.eol()
+        return Field(name.strip(), type_, bits)
+
+    def _parse_field_type(self, type_: BaseType, name: str) -> tuple[BaseType, str, Optional[int]]:
         pattern = self.TOK.patterns[self.TOK.NAME]
         # Dirty trick because the regex expects a ; but we don't want it to be part of the value
-        d = pattern.match(nametok.value + ";").groupdict()
+        d = pattern.match(name + ";").groupdict()
 
         name = d["name"]
         count_expression = d["count"]
@@ -269,8 +287,7 @@ class TokenParser(Parser):
 
                 type_ = Array(self.cstruct, type_, count)
 
-        tokens.eol()
-        return Field(name, type_, int(d["bits"]) if d["bits"] else None)
+        return type_, name, int(d["bits"]) if d["bits"] else None
 
     def _names(self, tokens: TokenConsumer) -> List[str]:
         names = []

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -578,6 +578,11 @@ def test_typedef_types():
     cdef = """
     typedef char uuid_t[16];
     typedef uint32 *ptr;
+
+    struct test {
+        uuid_t uuid;
+        ptr ptr;
+    };
     """
     cs = cstruct.cstruct(pointer="uint8")
     cs.load(cdef)
@@ -588,3 +593,7 @@ def test_typedef_types():
     assert isinstance(cs.ptr, Pointer)
     assert cs.ptr(b"\x01AAAA") == 1
     assert cs.ptr(b"\x01AAAA").dereference() == 0x41414141
+
+    obj = cs.test(b"\x01" * 16 + b"\x11AAAA")
+    assert obj.uuid == b"\x01" * 16
+    assert obj.ptr.dereference() == 0x41414141

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -597,3 +597,6 @@ def test_typedef_types():
     obj = cs.test(b"\x01" * 16 + b"\x11AAAA")
     assert obj.uuid == b"\x01" * 16
     assert obj.ptr.dereference() == 0x41414141
+
+    with pytest.raises(ParserError, match="line 1: typedefs cannot have bitfields"):
+        cs.load("""typedef uint8 with_bits : 4;""")


### PR DESCRIPTION
While the current syntax parser is quite restricting and due a rewrite, this will add support for a long time outstanding annoyance where the following syntax would not behave as expected:

```c
typedef char uuid_t[16];
```

Previously, this would simply add a type alias for `"char"` as the literal string `"uuid_t[16]"`. With this PR, this finally behaves as expected and allows you to typedef UUID character arrays!