### PR TITLE
Fix colored hexdumps for zero-length field values

### DIFF
--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -56,7 +56,12 @@ def _hexdump(data: bytes, palette: Palette = None, offset: int = 0, prefix: str 
             if not active and palette:
                 remaining, active = palette.pop()
                 while remaining == 0:
-                    remaining, active = palette.pop()
+                    if len(palette) == 0:
+                        # Last palette tuple is empty: print remaining whitespaces
+                        active = ""
+                        break
+                    else:
+                        remaining, active = palette.pop()
                 values += active
             elif active and j == 0:
                 values += active

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -55,6 +55,8 @@ def _hexdump(data: bytes, palette: Palette = None, offset: int = 0, prefix: str 
         for j in range(16):
             if not active and palette:
                 remaining, active = palette.pop()
+                while remaining == 0:
+                    remaining, active = palette.pop()
                 values += active
             elif active and j == 0:
                 values += active


### PR DESCRIPTION
Fix a (very, very) minor bug in dumpstruct for structure instances where field values are of length 0. In such situations, the coloring scheme of the hexdump currently 'hangs'. See the screenshot below:

![Screenshot from 2024-04-22 20-56-14](https://github.com/fox-it/dissect.cstruct/assets/19346100/53e9efda-7dd4-46e1-ac37-d6081b62c930)
`main` on the left, the branch for this PR on the right. The difference is in line 10.
