### PR TITLE
Use __align__ instead of align in StructureMetaType.__init__

### DIFF
--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -49,7 +49,7 @@ class StructureMetaType(MetaType):
 
     def __new__(metacls, name: str, bases: tuple[type, ...], classdict: dict[str, Any]) -> MetaType:
         if (fields := classdict.pop("fields", None)) is not None:
-            metacls._update_fields(metacls, fields, align=classdict.get("align", False), classdict=classdict)
+            metacls._update_fields(metacls, fields, align=classdict.get("__align__", False), classdict=classdict)
 
         return super().__new__(metacls, name, bases, classdict)
 

--- a/tests/test_types_structure.py
+++ b/tests/test_types_structure.py
@@ -533,9 +533,7 @@ def test_structure_definition_self(cs: cstruct) -> None:
 
 def test_align_struct_in_struct(cs: cstruct) -> None:
     with patch.object(StructureMetaType, "_update_fields") as update_fields:
-        fields = [Field("a", cs.uint64)]
-        cs._make_struct("test", fields, align=True)
-        args, kwargs = update_fields.call_args
-        new_kwargs = kwargs.copy()
-        new_kwargs.update({"align": True})
-        update_fields.assert_called_with(*args, **new_kwargs)
+        cs._make_struct("test", [Field("a", cs.uint64)], align=True)
+
+        _, kwargs = update_fields.call_args
+        assert kwargs["align"]

--- a/tests/test_types_structure.py
+++ b/tests/test_types_structure.py
@@ -9,7 +9,7 @@ from dissect.cstruct.cstruct import cstruct
 from dissect.cstruct.exceptions import ParserError
 from dissect.cstruct.types.base import Array, BaseType
 from dissect.cstruct.types.pointer import Pointer
-from dissect.cstruct.types.structure import Field, Structure
+from dissect.cstruct.types.structure import Field, Structure, StructureMetaType
 
 from .utils import verify_compiled
 
@@ -529,3 +529,13 @@ def test_structure_definition_self(cs: cstruct) -> None:
 
     assert issubclass(cs.test.fields["b"].type, Pointer)
     assert cs.test.fields["b"].type.type is cs.test
+
+
+def test_align_struct_in_struct(cs: cstruct) -> None:
+    with patch.object(StructureMetaType, "_update_fields") as update_fields:
+        fields = [Field("a", cs.uint64)]
+        cs._make_struct("test", fields, align=True)
+        args, kwargs = update_fields.call_args
+        new_kwargs = kwargs.copy()
+        new_kwargs.update({"align": True})
+        update_fields.assert_called_with(*args, **new_kwargs)


### PR DESCRIPTION
This wil fix an error where fields did not get properly aligned in a struct
<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
