### PR TITLE
fix offsets in generate fields

### DIFF
--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -198,8 +198,11 @@ class _ReadSourceGenerator:
                     prev_was_bits = True
 
                 if bits_remaining == 0 or prev_bits_type != field_type:
-                    bits_remaining = (size * 8) - field.bits
-                    bits_rollover = True
+                    if bits_remaining == field.bits:
+                        bits_remaining = 0
+                    else:
+                        bits_remaining = (size * 8) - field.bits
+                        bits_rollover = True
 
                 yield from flush()
                 yield from align_to_field(field)

--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -109,6 +109,7 @@ class _ReadSourceGenerator:
         preamble = """
         r = {}
         s = {}
+        o = stream.tell()
         """
 
         if any(field.bits for field in self.fields):
@@ -150,7 +151,7 @@ class _ReadSourceGenerator:
 
             if field.offset is not None and field.offset != current_offset:
                 # If a field has a set offset and it's not the same as the current tracked offset, seek to it
-                yield f"stream.seek({field.offset})"
+                yield f"stream.seek(o + {field.offset})"
                 current_offset = field.offset
 
             if self.align and field.offset is None:
@@ -198,11 +199,8 @@ class _ReadSourceGenerator:
                     prev_was_bits = True
 
                 if bits_remaining == 0 or prev_bits_type != field_type:
-                    if bits_remaining == field.bits:
-                        bits_remaining = 0
-                    else:
-                        bits_remaining = (size * 8) - field.bits
-                        bits_rollover = True
+                    bits_remaining = (size * 8) - field.bits
+                    bits_rollover = True
 
                 yield from flush()
                 yield from align_to_field(field)

--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -26,6 +26,7 @@ from dissect.cstruct.types import (
     Wchar,
     WcharArray,
 )
+from dissect.cstruct.types.enum import EnumMetaType
 from dissect.cstruct.types.packed import _struct
 
 if TYPE_CHECKING:
@@ -158,6 +159,9 @@ class _ReadSourceGenerator:
         for field in self.fields:
             field_type = self.cs.resolve(field.type)
 
+            if isinstance(field_type, EnumMetaType):
+                field_type = field_type.type
+
             if not issubclass(field_type, SUPPORTED_TYPES):
                 raise TypeError(f"Unsupported type for compiler: {field_type}")
 
@@ -190,10 +194,10 @@ class _ReadSourceGenerator:
             # Bit fields
             elif field.bits:
                 if not prev_was_bits:
-                    prev_bits_type = field.type
+                    prev_bits_type = field_type
                     prev_was_bits = True
 
-                if bits_remaining == 0 or prev_bits_type != field.type:
+                if bits_remaining == 0 or prev_bits_type != field_type:
                     bits_remaining = (size * 8) - field.bits
                     bits_rollover = True
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -324,3 +324,37 @@ def test_generate_bits_read(cs: cstruct, TestEnum: type[Enum]) -> None:
 
 
 # TODO: the rest of the compiler
+def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum) -> None:
+    fields = [
+        Field("size", cs.uint16, offset=0),
+        Field("a", cs.uint8, 4, offset=2),
+        Field("b", TestEnum, 4),
+        Field("c", cs.char["size"], offset=3),
+    ]
+
+    output = "\n".join(compiler._ReadSourceGenerator(cs, fields)._generate_fields())
+
+    expected = """
+    buf = stream.read(2)
+    if len(buf) != 2: raise EOFError()
+    data = _struct(cls.cs.endian, "H").unpack(buf)
+
+    r["size"] = type.__call__(_0, data[0])
+    s["size"] = 2
+
+
+    _t = _1
+    r["a"] = type.__call__(_t, bit_reader.read(_t, 4))
+
+
+    _t = _2
+    r["b"] = type.__call__(_t, bit_reader.read(_t.type, 4))
+
+    bit_reader.reset()
+
+    _s = stream.tell()
+    r["c"] = _3._read(stream, context=r)
+    s["c"] = stream.tell() - _s
+    """
+
+    assert output.strip() == dedent(expected).strip()

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -324,7 +324,7 @@ def test_generate_bits_read(cs: cstruct, TestEnum: type[Enum]) -> None:
 
 
 # TODO: the rest of the compiler
-@pytest.mark.parametrize("other_type", ["uint8", "int8", "uint64"])
+@pytest.mark.parametrize("other_type", ["int8", "uint64"])
 def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, other_type: str) -> None:
     _type = getattr(cs, other_type)
 
@@ -354,6 +354,7 @@ def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, oth
     r["b"] = type.__call__(_t, bit_reader.read(_t, 4))
 
     bit_reader.reset()
+    stream.seek(o + 3)
 
     _s = stream.tell()
     r["c"] = _3._read(stream, context=r)
@@ -364,7 +365,7 @@ def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, oth
 
 
 # TODO: the rest of the compiler
-@pytest.mark.parametrize("other_type", ["uint8", "int8", "uint64"])
+@pytest.mark.parametrize("other_type", ["int8", "uint64"])
 def test_generate_fields_dynamic_after_bitfield_reverse(cs: cstruct, TestEnum: Enum, other_type: str) -> None:
     _type = getattr(cs, other_type)
 
@@ -394,6 +395,7 @@ def test_generate_fields_dynamic_after_bitfield_reverse(cs: cstruct, TestEnum: E
     r["b"] = type.__call__(_t, bit_reader.read(_t.type, 4))
 
     bit_reader.reset()
+    stream.seek(o + 3)
 
     _s = stream.tell()
     r["c"] = _3._read(stream, context=r)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -323,7 +323,6 @@ def test_generate_bits_read(cs: cstruct, TestEnum: type[Enum]) -> None:
     assert code == dedent(expected)
 
 
-# TODO: the rest of the compiler
 @pytest.mark.parametrize("other_type", ["int8", "uint64"])
 def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, other_type: str) -> None:
     _type = getattr(cs, other_type)
@@ -364,9 +363,8 @@ def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, oth
     assert output.strip() == dedent(expected).strip()
 
 
-# TODO: the rest of the compiler
 @pytest.mark.parametrize("other_type", ["int8", "uint64"])
-def test_generate_fields_dynamic_after_bitfield_reverse(cs: cstruct, TestEnum: Enum, other_type: str) -> None:
+def test_generate_fields_dynamic_before_bitfield(cs: cstruct, TestEnum: Enum, other_type: str) -> None:
     _type = getattr(cs, other_type)
 
     fields = [

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -324,10 +324,53 @@ def test_generate_bits_read(cs: cstruct, TestEnum: type[Enum]) -> None:
 
 
 # TODO: the rest of the compiler
-def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum) -> None:
+@pytest.mark.parametrize("other_type", ["uint8", "int8", "uint64"])
+def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, other_type: str) -> None:
+    _type = getattr(cs, other_type)
+
     fields = [
         Field("size", cs.uint16, offset=0),
-        Field("a", cs.uint8, 4, offset=2),
+        Field("a", TestEnum, 4, offset=2),
+        Field("b", _type, 4),
+        Field("c", cs.char["size"], offset=3),
+    ]
+
+    output = "\n".join(compiler._ReadSourceGenerator(cs, fields)._generate_fields())
+
+    expected = """
+    buf = stream.read(2)
+    if len(buf) != 2: raise EOFError()
+    data = _struct(cls.cs.endian, "H").unpack(buf)
+
+    r["size"] = type.__call__(_0, data[0])
+    s["size"] = 2
+
+
+    _t = _1
+    r["a"] = type.__call__(_t, bit_reader.read(_t.type, 4))
+
+
+    _t = _2
+    r["b"] = type.__call__(_t, bit_reader.read(_t, 4))
+
+    bit_reader.reset()
+
+    _s = stream.tell()
+    r["c"] = _3._read(stream, context=r)
+    s["c"] = stream.tell() - _s
+    """
+
+    assert output.strip() == dedent(expected).strip()
+
+
+# TODO: the rest of the compiler
+@pytest.mark.parametrize("other_type", ["uint8", "int8", "uint64"])
+def test_generate_fields_dynamic_after_bitfield_reverse(cs: cstruct, TestEnum: Enum, other_type: str) -> None:
+    _type = getattr(cs, other_type)
+
+    fields = [
+        Field("size", cs.uint16, offset=0),
+        Field("a", _type, 4, offset=2),
         Field("b", TestEnum, 4),
         Field("c", cs.char["size"], offset=3),
     ]


### PR DESCRIPTION
- Unpack enum when generating fields.
- Align bit fields better

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
