### PR TITLE
Fix unhashable code objects of generated classes

### DIFF
--- a/dissect/cstruct/types/enum.py
+++ b/dissect/cstruct/types/enum.py
@@ -77,7 +77,7 @@ class EnumMetaType(EnumMeta, MetaType):
     __len__ = MetaType.__len__
 
     def __contains__(cls, value: Any) -> bool:
-        # We used to let stdlib enum handle `__containts``` but this commit is incompatible with our API:
+        # We used to let stdlib enum handle `__contains__``` but this commit is incompatible with our API:
         # https://github.com/python/cpython/commit/8a9aee71268c77867d3cc96d43cbbdcbe8c0e1e8
         if isinstance(value, cls):
             return True

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -783,7 +783,7 @@ def _generate_structure__init__(fields: list[Field]) -> FunctionType:
     template: FunctionType = _make_structure__init__(len(field_names))
     return type(template)(
         template.__code__.replace(
-            co_names=(*chain.from_iterable(zip((f"__{name}_default__" for name in field_names), field_names)),),
+            co_names=tuple(chain.from_iterable(zip((f"__{name}_default__" for name in field_names), field_names))),
             co_varnames=("self", *field_names),
         ),
         template.__globals__ | {f"__{field._name}_default__": field.type.__default__() for field in fields},

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -673,7 +673,9 @@ def _make_structure__init__(fields: list[str]) -> str:
         fields: List of field names.
     """
     field_args = ", ".join(f"{field} = None" for field in fields)
-    field_init = "\n".join(f" self.{name} = {name} if {name} is not None else {i}" for i, name in enumerate(fields))
+    field_init = "\n".join(
+        f" self.{name} = {name} if {name} is not None else _{i}_default" for i, name in enumerate(fields)
+    )
 
     code = f"def __init__(self{', ' + field_args or ''}):\n"
     return code + (field_init or " pass")
@@ -688,7 +690,8 @@ def _make_union__init__(fields: list[str]) -> str:
     """
     field_args = ", ".join(f"{field} = None" for field in fields)
     field_init = "\n".join(
-        f" object.__setattr__(self, '{name}', {name} if {name} is not None else {i})" for i, name in enumerate(fields)
+        f" object.__setattr__(self, '{name}', {name} if {name} is not None else _{i}_default)"
+        for i, name in enumerate(fields)
     )
 
     code = f"def __init__(self{', ' + field_args or ''}):\n"
@@ -780,11 +783,10 @@ def _generate_structure__init__(fields: list[Field]) -> FunctionType:
     template: FunctionType = _make_structure__init__(len(field_names))
     return type(template)(
         template.__code__.replace(
-            co_consts=(None, *[field.type.__default__() for field in fields]),
-            co_names=(*field_names,),
+            co_names=(*chain.from_iterable(zip((f"__{name}_default__" for name in field_names), field_names)),),
             co_varnames=("self", *field_names),
         ),
-        template.__globals__,
+        template.__globals__ | {f"__{field._name}_default__": field.type.__default__() for field in fields},
         argdefs=template.__defaults__,
     )
 
@@ -800,13 +802,11 @@ def _generate_union__init__(fields: list[Field]) -> FunctionType:
     template: FunctionType = _make_union__init__(len(field_names))
     return type(template)(
         template.__code__.replace(
-            co_consts=(
-                None,
-                *sum([(field._name, field.type.__default__()) for field in fields], ()),
-            ),
+            co_consts=(None, *field_names),
+            co_names=("object", "__setattr__", *(f"__{name}_default__" for name in field_names)),
             co_varnames=("self", *field_names),
         ),
-        template.__globals__,
+        template.__globals__ | {f"__{field._name}_default__": field.type.__default__() for field in fields},
         argdefs=template.__defaults__,
     )
 

--- a/tests/test_types_union.py
+++ b/tests/test_types_union.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from dissect.cstruct.types import structure
 from dissect.cstruct.types.base import Array, BaseType
 from dissect.cstruct.types.structure import Field, Union, UnionProxy
 
@@ -535,3 +536,14 @@ def test_union_partial_initialization_dynamic(cs: cstruct) -> None:
 
     with pytest.raises(NotImplementedError, match="Initializing a dynamic union is not yet supported"):
         cs.test(x=1)
+
+
+def test_codegen_hashable(cs: cstruct) -> None:
+    hashable_fields = [Field("a", cs.uint8), Field("b", cs.uint8)]
+    unhashable_fields = [Field("a", cs.uint8[2]), Field("b", cs.uint8)]
+
+    with pytest.raises(TypeError, match="unhashable type: 'uint8\\[2\\]'"):
+        hash(unhashable_fields[0].type.__default__())
+
+    assert hash(structure._generate_union__init__(hashable_fields).__code__)
+    assert hash(structure._generate_union__init__(unhashable_fields).__code__)


### PR DESCRIPTION
Fixes #119.

We originally put type defaults in the `co_consts` on the code objects from the generated `__init__` methods. Turns out that code objects are expected to be hashable 😄 and some type defaults (like arrays/lists) are not.

Probably what we were doing wasn't strictly legal in CPython, but it just so happened to work fine. We can see that underwater, CPython will build a list using the `BUILD_LIST` and `LIST_EXTEND` opcodes, with a tuple constant as argument (function `a`). As an example I replaced the constant `0` in the `b` function with the value `[3, 4, 5]` and store it as function `c`. We can run the function fine, but the resulting `__code__` object is no longer hashable due to it having a list in `co_consts`.

```python
In [1]: import dis

In [2]: def a():
   ...:     var = [0, 1, 2]
   ...:     return var
   ...: 

In [3]: def b():
   ...:     var = 0
   ...:     return var
   ...: 

In [4]: dis.dis(a)
  1           0 RESUME                   0

  2           2 BUILD_LIST               0
              4 LOAD_CONST               1 ((0, 1, 2))
              6 LIST_EXTEND              1
              8 STORE_FAST               0 (var)

  3          10 LOAD_FAST                0 (var)
             12 RETURN_VALUE

In [5]: a.__code__.co_consts
Out[5]: (None, (0, 1, 2))

In [6]: dis.dis(b)
  1           0 RESUME                   0

  2           2 LOAD_CONST               1 (0)
              4 STORE_FAST               0 (var)

  3           6 LOAD_FAST                0 (var)
              8 RETURN_VALUE

In [7]: b.__code__.co_consts
Out[7]: (None, 0)

In [8]: c = type(b)(b.__code__.replace(co_consts=(None, [3, 4, 5])), b.__globals__)

In [9]: dis.dis(c)
  1           0 RESUME                   0

  2           2 LOAD_CONST               1 ([3, 4, 5])
              4 STORE_FAST               0 (var)

  3           6 LOAD_FAST                0 (var)
              8 RETURN_VALUE

In [10]: c.__code__.co_consts
Out[10]: (None, [3, 4, 5])

In [11]: a()
Out[11]: [0, 1, 2]

In [12]: b()
Out[12]: 0

In [13]: c()
Out[13]: [3, 4, 5]

In [14]: hash(a.__code__)
Out[14]: 7471609077247281477

In [15]: hash(b.__code__)
Out[15]: -1636199677561223399

In [16]: hash(c.__code__)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[16], line 1
----> 1 hash(c.__code__)

TypeError: unhashable type: 'list'
```

I've solved this by moving the defaults to the bound `__globals__`. As far as I can tell, anything is allowed in there and it's only a very small change from the existing code.