### PR TITLE
Save space saving sizes of dynamic fields only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,53 @@
-# cstruct version 4.6
-Release date: tbc
+# Changelog
 
-## Library
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed
+
 - Optimize storage of field sizes.
-- Rename `_sizes` property of `Structure` to `__sizes__`. 
+- Rename `_sizes` property of `Structure` to `__sizes__`.
 - Rename `_values` property of `Structure` to `__values__`.
+
+## [4.5] - 20-05-2025
+
+### Added 
+
+- Introduce experimental tool `cstruct-stubgen` to generate type stubs for cstruct definitions.
+
+### Fixed
+
+- Generated classes are now hashable.
+- Suppress spurious `TypeError: Dynamic size` errors when using cstruct interactively.
+
+## [4.4] - 03-10-2025
+
+### Fixed
+
+- Resolve documentation warnings.
+
+### Changed
+
+- Use the Ruff linter.
+
+## [4.3] - 11-18-2024
+
+### Fixed
+
+- All cstruct types are now correctly default-initialized using the `__default__` member.
+
+## [4.2] - 10-10-2024
+
+### Fixed
+
+- The string representation of enums now outputs the name of the constants. 
+
+## [4.1] - 10-09-2024
+
+### Fixed
+
+- Declaring an array of a nested struct type now works as intended.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# cstruct version 4.6
+Release date: tbc
+
+## Library
+- Optimize storage of field sizes.
+- Rename `_sizes` property of `Structure` to `__sizes__`. 
+- Rename `_values` property of `Structure` to `__values__`.

--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -123,8 +123,8 @@ class _ReadSourceGenerator:
 
         outro = """
         obj = type.__call__(cls, **r)
-        obj._sizes = s
-        obj._values = r
+        obj.__dynamic_sizes__ = s
+        obj.__values__ = r
 
         return obj
         """

--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -227,18 +227,18 @@ class _ReadSourceGenerator:
 
     def _generate_structure(self, field: Field) -> Iterator[str]:
         template = f"""
-        _s = stream.tell()
+        {'_s = stream.tell()' if field.type.dynamic else ''}
         r["{field._name}"] = {self._map_field(field)}._read(stream, context=r)
-        s["{field._name}"] = stream.tell() - _s
+        {f's["{field._name}"] = stream.tell() - _s' if field.type.dynamic else ''}
         """
 
         yield dedent(template)
 
     def _generate_array(self, field: Field) -> Iterator[str]:
         template = f"""
-        _s = stream.tell()
+        {'_s = stream.tell()' if field.type.dynamic else ''}
         r["{field._name}"] = {self._map_field(field)}._read(stream, context=r)
-        s["{field._name}"] = stream.tell() - _s
+        {f's["{field._name}"] = stream.tell() - _s' if field.type.dynamic else ''}
         """
 
         yield dedent(template)
@@ -326,7 +326,6 @@ class _ReadSourceGenerator:
                 parser = parser_template.format(type=self._map_field(field), getter=getter)
 
             reads.append(f'r["{field._name}"] = {parser}')
-            reads.append(f's["{field._name}"] = {field_type.size}')
             reads.append("")  # Generates a newline in the resulting code
 
             size += field_type.size

--- a/dissect/cstruct/compiler.py
+++ b/dissect/cstruct/compiler.py
@@ -124,7 +124,6 @@ class _ReadSourceGenerator:
         outro = """
         obj = type.__call__(cls, **r)
         obj.__dynamic_sizes__ = s
-        obj.__values__ = r
 
         return obj
         """

--- a/dissect/cstruct/expression.py
+++ b/dissect/cstruct/expression.py
@@ -187,8 +187,7 @@ class Expression:
         "sizeof": 6,
     }
 
-    def __init__(self, cstruct: cstruct, expression: str):
-        self.cstruct = cstruct
+    def __init__(self, expression: str):
         self.expression = expression
         self.tokens = ExpressionTokenizer(expression).tokenize()
         self.stack = []
@@ -222,7 +221,7 @@ class Expression:
     def is_number(self, token: str) -> bool:
         return token.isnumeric() or (len(token) > 2 and token[0] == "0" and token[1] in ("x", "X", "b", "B", "o", "O"))
 
-    def evaluate(self, context: dict[str, int] | None = None) -> int:
+    def evaluate(self, cs: cstruct, context: dict[str, int] | None = None) -> int:
         """Evaluates an expression using a Shunting-Yard implementation."""
 
         self.stack = []
@@ -249,14 +248,14 @@ class Expression:
                 self.queue.append(int(current_token, 0))
             elif current_token in context:
                 self.queue.append(int(context[current_token]))
-            elif current_token in self.cstruct.consts:
-                self.queue.append(int(self.cstruct.consts[current_token]))
+            elif current_token in cs.consts:
+                self.queue.append(int(cs.consts[current_token]))
             elif current_token in self.unary_operators:
                 self.stack.append(current_token)
             elif current_token == "sizeof":
                 if len(tmp_expression) < i + 3 or (tmp_expression[i + 1] != "(" or tmp_expression[i + 3] != ")"):
                     raise ExpressionParserError("Invalid sizeof operation")
-                self.queue.append(len(self.cstruct.resolve(tmp_expression[i + 2])))
+                self.queue.append(len(cs.resolve(tmp_expression[i + 2])))
                 i += 3
             elif current_token in operators:
                 while (

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -92,7 +92,7 @@ class TokenParser(Parser):
 
         if isinstance(value, str):
             try:
-                value = Expression(self.cstruct, value).evaluate()
+                value = Expression(value).evaluate(self.cstruct)
             except (ExpressionParserError, ExpressionTokenizerError):
                 pass
 
@@ -120,7 +120,7 @@ class TokenParser(Parser):
                 if not key:
                     continue
 
-                val = nextval if not val else Expression(self.cstruct, val).evaluate(values)
+                val = nextval if not val else Expression(val).evaluate(self.cstruct, values)
 
                 if enumtype == "flag":
                     high_bit = val.bit_length() - 1
@@ -293,9 +293,9 @@ class TokenParser(Parser):
                 if count == "":
                     count = None
                 else:
-                    count = Expression(self.cstruct, count)
+                    count = Expression(count)
                     try:
-                        count = count.evaluate()
+                        count = count.evaluate(self.cstruct)
                     except Exception:
                         pass
 
@@ -434,7 +434,7 @@ class CStyleParser(Parser):
                     if not key:
                         continue
 
-                    val = nextval if not val else Expression(self.cstruct, val).evaluate()
+                    val = nextval if not val else Expression(val).evaluate(self.cstruct)
 
                     if enumtype == "flag":
                         high_bit = val.bit_length() - 1
@@ -515,9 +515,9 @@ class CStyleParser(Parser):
                 if d["count"] == "":
                     count = None
                 else:
-                    count = Expression(self.cstruct, d["count"])
+                    count = Expression(d["count"])
                     try:
-                        count = count.evaluate()
+                        count = count.evaluate(self.cstruct)
                     except Exception:
                         pass
 

--- a/dissect/cstruct/types/base.py
+++ b/dissect/cstruct/types/base.py
@@ -262,7 +262,7 @@ class BaseArray(BaseType):
             num = EOF
         elif isinstance(cls.num_entries, Expression):
             try:
-                num = max(0, cls.num_entries.evaluate(context))
+                num = max(0, cls.num_entries.evaluate(cls.cs, context))
             except Exception:
                 if cls.num_entries.expression != "EOF":
                     raise

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -412,12 +412,12 @@ class Structure(BaseType, metaclass=StructureMetaType):
         return f"<{self.__class__.__name__} {' '.join(values)}>"
 
     @property
-    def __sizes__(self) -> Mapping[str, int | None]:
-        return ChainMap(self.__class__.__static_sizes__, self.__dynamic_sizes__)
-
-    @property
     def __values__(self) -> MutableMapping[str, Any]:
         return StructureValuesProxy(self)
+
+    @property
+    def __sizes__(self) -> Mapping[str, int | None]:
+        return ChainMap(self.__class__.__static_sizes__, self.__dynamic_sizes__)
 
 
 class StructureValuesProxy(MutableMapping):
@@ -433,9 +433,8 @@ class StructureValuesProxy(MutableMapping):
 
     def __setitem__(self, key: str, value: Any) -> None:
         if key in self:
-            setattr(self._struct, key, value)
-        else:
-            raise KeyError(key)
+            return setattr(self._struct, key, value)
+        raise KeyError(key)
 
     def __contains__(self, key: str) -> bool:
         return key in self._struct.__class__.fields
@@ -447,8 +446,7 @@ class StructureValuesProxy(MutableMapping):
         return len(self._struct.__class__.fields)
 
     def __repr__(self) -> str:
-        items = (f"{key!r}: {value!r}" for (key, value) in self.items())
-        return "{" + ", ".join(items) + "}"
+        return repr(dict(self))
 
     def __delitem__(self, _: str):
         # Is abstract in base, but deleting is not supported.

--- a/dissect/cstruct/types/structure.py
+++ b/dissect/cstruct/types/structure.py
@@ -151,6 +151,7 @@ class StructureMetaType(MetaType):
 
         return classdict
 
+
     def _calculate_size_and_offsets(cls, fields: list[Field], align: bool = False) -> tuple[int | None, int]:
         """Iterate all fields in this structure to calculate the field offsets and total structure size.
 
@@ -271,8 +272,9 @@ class StructureMetaType(MetaType):
 
             value = field.type._read(stream, result)
 
-            sizes[field._name] = stream.tell() - offset
             result[field._name] = value
+            if field.type.dynamic:
+                sizes[field._name] = stream.tell() - offset
 
         if cls.__align__:
             # Align the stream
@@ -473,8 +475,9 @@ class UnionMetaType(StructureMetaType):
             buf.seek(offset + start)
             value = field_type._read(buf, result)
 
-            sizes[field._name] = buf.tell() - start
             result[field._name] = value
+            if field.type.dynamic:
+                sizes[field._name] = buf.tell() - start
 
         return result, sizes
 

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -169,7 +169,7 @@ def _dumpstruct(
 
         if color:
             foreground, background = colors[ci % len(colors)]
-            size = structure.sizes[field._name]
+            size = structure.__sizes__[field._name]
             palette.append((size, background))
             ci += 1
             out.append(f"- {foreground}{field._name}{COLOR_NORMAL}: {value}")

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -169,7 +169,7 @@ def _dumpstruct(
 
         if color:
             foreground, background = colors[ci % len(colors)]
-            size = structure._sizes[field._name] if field.type.dynamic else field.type.size
+            size = structure.sizes[field._name]
             palette.append((size, background))
             ci += 1
             out.append(f"- {foreground}{field._name}{COLOR_NORMAL}: {value}")

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -157,11 +157,6 @@ def _dumpstruct(
         if getattr(field.type, "anonymous", False):
             continue
 
-        if color:
-            foreground, background = colors[ci % len(colors)]
-            palette.append((structure._sizes[field._name], background))
-        ci += 1
-
         value = getattr(structure, field._name)
         if isinstance(value, (str, Pointer, Enum)):
             value = repr(value)
@@ -173,6 +168,10 @@ def _dumpstruct(
                 value = value.replace("\n", f"\n{' ' * (len(field._name) + 4)}")
 
         if color:
+            foreground, background = colors[ci % len(colors)]
+            size = structure._sizes[field._name] if field.type.dynamic else field.type.size
+            palette.append((size, background))
+            ci += 1
             out.append(f"- {foreground}{field._name}{COLOR_NORMAL}: {value}")
         else:
             out.append(f"- {field._name}: {value}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dynamic = ["version"]
 homepage = "https://dissect.tools"
 documentation = "https://docs.dissect.tools/en/latest/projects/dissect.cstruct"
 repository = "https://github.com/fox-it/dissect.cstruct"
+changelog = "https://github.com/fox-it/dissect.cstruct/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -45,7 +45,7 @@ def test_align_struct(cs: cstruct, compiled: bool) -> None:
     obj = cs.test(fh)
     assert fh.tell() == 32
 
-    for name, value in obj._values.items():
+    for name, value in obj.__values__.items():
         assert cs.test.fields[name].offset == value
 
     assert obj.dumps() == buf

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -111,16 +111,12 @@ def test_generate_packed_read(cs: cstruct) -> None:
     data = _struct(cls.cs.endian, "BhIq").unpack(buf)
 
     r["a"] = type.__call__(_0, data[0])
-    s["a"] = 1
 
     r["b"] = type.__call__(_1, data[1])
-    s["b"] = 2
 
     r["c"] = type.__call__(_2, data[2])
-    s["c"] = 4
 
     r["d"] = type.__call__(_3, data[3])
-    s["d"] = 8
     """
 
     assert code == dedent(expected)
@@ -143,22 +139,18 @@ def test_generate_packed_read_array(cs: cstruct) -> None:
     _t = _0
     _et = _t.type
     r["a"] = type.__call__(_t, [type.__call__(_et, e) for e in data[0:2]])
-    s["a"] = 2
 
     _t = _1
     _et = _t.type
     r["b"] = type.__call__(_t, [type.__call__(_et, e) for e in data[2:5]])
-    s["b"] = 6
 
     _t = _2
     _et = _t.type
     r["c"] = type.__call__(_t, [type.__call__(_et, e) for e in data[5:9]])
-    s["c"] = 16
 
     _t = _3
     _et = _t.type
     r["d"] = type.__call__(_t, [type.__call__(_et, e) for e in data[9:14]])
-    s["d"] = 40
     """
 
     assert code == dedent(expected)
@@ -181,25 +173,19 @@ def test_generate_packed_read_byte_types(cs: cstruct) -> None:
     data = _struct(cls.cs.endian, "18x").unpack(buf)
 
     r["a"] = type.__call__(_0, buf[0:1])
-    s["a"] = 1
 
     r["b"] = type.__call__(_1, buf[1:3])
-    s["b"] = 2
 
     r["c"] = _2(buf[3:5])
-    s["c"] = 2
 
     r["d"] = _3(buf[5:9])
-    s["d"] = 4
 
     r["e"] = _4(buf[9:12])
-    s["e"] = 3
 
     _t = _5
     _et = _t.type
     _b = buf[12:18]
     r["f"] = type.__call__(_t, [_et(_b[i:i + 3]) for i in range(0, 6, 3)])
-    s["f"] = 6
     """
 
     assert code == dedent(expected)
@@ -223,16 +209,13 @@ def test_generate_packed_read_composite_types(cs: cstruct, TestEnum: type[Enum])
     data = _struct(cls.cs.endian, "BQ2B").unpack(buf)
 
     r["a"] = type.__call__(_0, data[0])
-    s["a"] = 1
 
     _pt = _1
     r["b"] = _pt.__new__(_pt, data[1], stream, r)
-    s["b"] = 8
 
     _t = _2
     _et = _t.type
     r["c"] = type.__call__(_t, [type.__call__(_et, e) for e in data[2:4]])
-    s["c"] = 2
     """
 
     assert code == dedent(expected)
@@ -251,10 +234,8 @@ def test_generate_packed_read_offsets(cs: cstruct) -> None:
     data = _struct(cls.cs.endian, "B7xB").unpack(buf)
 
     r["a"] = type.__call__(_0, data[0])
-    s["a"] = 1
 
     r["b"] = type.__call__(_1, data[1])
-    s["b"] = 1
     """
 
     assert code == dedent(expected)
@@ -337,6 +318,7 @@ def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, oth
         Field("b", _type, 4),
         Field("c", cs.char["size"], offset=3),
     ]
+    fields[3].type.dynamic = True   # cs.char["size"] is a hack so patch dynamic
 
     output = "\n".join(compiler._ReadSourceGenerator(cs, fields)._generate_fields())
 
@@ -346,7 +328,6 @@ def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, oth
     data = _struct(cls.cs.endian, "H").unpack(buf)
 
     r["size"] = type.__call__(_0, data[0])
-    s["size"] = 2
 
 
     _t = _1
@@ -377,6 +358,7 @@ def test_generate_fields_dynamic_before_bitfield(cs: cstruct, TestEnum: Enum, ot
         Field("b", TestEnum, 4),
         Field("c", cs.char["size"], offset=3),
     ]
+    fields[3].type.dynamic = True   # cs.char["size"] is a hack so patch dynamic
 
     output = "\n".join(compiler._ReadSourceGenerator(cs, fields)._generate_fields())
 
@@ -386,7 +368,6 @@ def test_generate_fields_dynamic_before_bitfield(cs: cstruct, TestEnum: Enum, ot
     data = _struct(cls.cs.endian, "H").unpack(buf)
 
     r["size"] = type.__call__(_0, data[0])
-    s["size"] = 2
 
 
     _t = _1

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 import pytest
 
 from dissect.cstruct import compiler
+from dissect.cstruct.expression import Expression
 from dissect.cstruct.types.structure import Field
 
 if TYPE_CHECKING:
@@ -316,9 +317,8 @@ def test_generate_fields_dynamic_after_bitfield(cs: cstruct, TestEnum: Enum, oth
         Field("size", cs.uint16, offset=0),
         Field("a", TestEnum, 4, offset=2),
         Field("b", _type, 4),
-        Field("c", cs.char["size"], offset=3),
+        Field("c", cs.char[Expression("size")], offset=3),
     ]
-    fields[3].type.dynamic = True   # cs.char["size"] is a hack so patch dynamic
 
     output = "\n".join(compiler._ReadSourceGenerator(cs, fields)._generate_fields())
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -356,9 +356,8 @@ def test_generate_fields_dynamic_before_bitfield(cs: cstruct, TestEnum: Enum, ot
         Field("size", cs.uint16, offset=0),
         Field("a", _type, 4, offset=2),
         Field("b", TestEnum, 4),
-        Field("c", cs.char["size"], offset=3),
+        Field("c", cs.char[Expression("size")], offset=3),
     ]
-    fields[3].type.dynamic = True   # cs.char["size"] is a hack so patch dynamic
 
     output = "\n".join(compiler._ReadSourceGenerator(cs, fields)._generate_fields())
 

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -88,8 +88,8 @@ def id_fn(val: Any) -> str | None:
 
 @pytest.mark.parametrize(("expression", "answer"), testdata, ids=id_fn)
 def test_expression(expression: str, answer: int) -> None:
-    parser = Expression(Consts(), expression)
-    assert parser.evaluate() == answer
+    parser = Expression(expression)
+    assert parser.evaluate(Consts()) == answer
 
 
 @pytest.mark.parametrize(
@@ -110,7 +110,7 @@ def test_expression(expression: str, answer: int) -> None:
 )
 def test_expression_failure(expression: str, exception: type, message: str) -> None:
     with pytest.raises(exception, match=message):
-        Expression(Consts(), expression).evaluate()
+        Expression(expression).evaluate(Consts())
 
 
 def test_sizeof(cs: cstruct) -> None:

--- a/tests/test_types_structure.py
+++ b/tests/test_types_structure.py
@@ -265,7 +265,7 @@ def test_structure_definition_simple(cs: cstruct, compiled: bool) -> None:
     with pytest.raises(AttributeError):
         obj.nope  # noqa: B018
 
-    assert obj._sizes == { "string": 7, "wstring": 10 }
+    assert obj.__dynamic_sizes__ == { "string": 7, "wstring": 10 }
     assert len(obj) == len(buf)
     assert obj.dumps() == buf
 

--- a/tests/test_types_structure.py
+++ b/tests/test_types_structure.py
@@ -266,6 +266,7 @@ def test_structure_definition_simple(cs: cstruct, compiled: bool) -> None:
         obj.nope  # noqa: B018
 
     assert obj.__dynamic_sizes__ == { "string": 7, "wstring": 10 }
+    assert obj.__sizes__ == { "magic": 4, "wmagic": 8, "a": 1, "b": 2, "c": 4, "string": 7, "wstring": 10 }
     assert len(obj) == len(buf)
     assert obj.dumps() == buf
 

--- a/tests/test_types_structure.py
+++ b/tests/test_types_structure.py
@@ -265,7 +265,7 @@ def test_structure_definition_simple(cs: cstruct, compiled: bool) -> None:
     with pytest.raises(AttributeError):
         obj.nope  # noqa: B018
 
-    assert obj._sizes["magic"] == 4
+    assert obj._sizes == { "string": 7, "wstring": 10 }
     assert len(obj) == len(buf)
     assert obj.dumps() == buf
 

--- a/tests/test_types_structure.py
+++ b/tests/test_types_structure.py
@@ -275,6 +275,39 @@ def test_structure_definition_simple(cs: cstruct, compiled: bool) -> None:
     obj.write(fh)
     assert fh.getvalue() == buf
 
+def test_structure_values_dict(cs: cstruct, compiled: bool) -> None:
+    cdef = """
+    struct test {
+        char    magic[4];
+        wchar   wmagic[4];
+        uint8   a;
+        uint16  b;
+        uint32  c;
+        char    string[];
+        wchar   wstring[];
+    };
+    """
+    cs.load(cdef, compiled=compiled)
+    buf = b"testt\x00e\x00s\x00t\x00\x01\x02\x03\x04\x05\x06\x07lalala\x00t\x00e\x00s\x00t\x00\x00\x00"
+    obj = cs.test(buf)
+
+    # Test reading all values
+    values = obj.__values__
+    assert values["magic"] == b"test"
+    assert values["wmagic"] == "test"
+    assert values["a"] == 0x01
+    assert values["b"] == 0x0302
+    assert values["c"] == 0x07060504
+    assert values["string"] == b"lalala"
+    assert values["wstring"] == "test"
+
+    # Test writing a single field through the proxy
+    values["a"] = 0xFF
+    assert obj.a == 0xFF
+
+    # Test dictionary methods
+    assert values.keys() == {"magic", "wmagic", "a", "b", "c", "string", "wstring"}
+
 
 def test_structure_definition_simple_be(cs: cstruct, compiled: bool) -> None:
     cdef = """


### PR DESCRIPTION
Currently,  actual sizes of all fields are stored inside the `_sizes` private member. This can cause high memory usage in some applications. 

This PR only stores the sizes of dynamic fields. Since most fields are static, we significantly reduce memory usage, utilities like `dumpstruct` still work as intended. 

Alternative solution considered: Remove `_sizes` completely. However, no alternative way has been found to reconstruct the number of bytes read. This would result in loss of the pretty colors in dump_struct, for example  
