### PR TITLE
[parser.py] add capability to parse keyword #include into the list c.…

### DIFF
--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -53,6 +53,7 @@ class cstruct:
 
         self.consts = {}
         self.lookups = {}
+        self.includes = []
         # fmt: off
         self.typedefs = {
             # Internal types

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -49,7 +49,6 @@ class TokenParser(Parser):
         self.compiled = compiled
         self.align = align
         self.TOK = self._tokencollection()
-        self.cstruct.includes = []
 
     @staticmethod
     def _tokencollection() -> TokenCollection:

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -330,7 +330,7 @@ class TokenParser(Parser):
         pattern = self.TOK.patterns[self.TOK.INCLUDE]
         match = pattern.match(include.value).groupdict()
 
-        self.cstruct.includes.append(match["name"].strip())
+        self.cstruct.includes.append(match["name"].strip().strip('"'))
 
     @staticmethod
     def _remove_comments(string: str) -> str:

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -331,7 +331,7 @@ class TokenParser(Parser):
         pattern = self.TOK.patterns[self.TOK.INCLUDE]
         match = pattern.match(include.value).groupdict()
 
-        self.cstruct.includes.append(match["name"])
+        self.cstruct.includes.append(match["name"].strip())
 
     @staticmethod
     def _remove_comments(string: str) -> str:

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -49,6 +49,7 @@ class TokenParser(Parser):
         self.compiled = compiled
         self.align = align
         self.TOK = self._tokencollection()
+        self.cstruct.includes = []
 
     @staticmethod
     def _tokencollection() -> TokenCollection:
@@ -324,17 +325,14 @@ class TokenParser(Parser):
                 names.extend([name.strip() for name in ntoken.value.strip().split(",")])
 
         return names
-        
+
     def _include(self, tokens: TokenConsumer) -> None:
         include = tokens.consume()
         pattern = self.TOK.patterns[self.TOK.INCLUDE]
         match = pattern.match(include.value).groupdict()
-        # create if list with incs does not exist
-        if not hasattr(self.cstruct, 'includes'):
-            self.cstruct.includes = []
 
         self.cstruct.includes.append(match["name"])
-        
+
     @staticmethod
     def _remove_comments(string: str) -> str:
         # https://stackoverflow.com/a/18381470

--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -330,7 +330,7 @@ class TokenParser(Parser):
         pattern = self.TOK.patterns[self.TOK.INCLUDE]
         match = pattern.match(include.value).groupdict()
 
-        self.cstruct.includes.append(match["name"].strip().strip('"'))
+        self.cstruct.includes.append(match["name"].strip().strip("'\""))
 
     @staticmethod
     def _remove_comments(string: str) -> str:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -145,10 +145,8 @@ def test_includes(cs: cstruct) -> None:
     """
     cs.load(cdef)
 
-    assert cs.includes[0] == "<stdint.h>"
-    assert cs.includes[1] == "myLib.h"
-    assert len(cs.includes) == 2
+    assert cs.includes == ["<stdint.h>", "myLib.h"]
     assert cs.myStruct.__name__ == "myStruct"
-    assert len(cs.typedefs["myStruct"].fields) == 1
-    assert cs.typedefs["myStruct"].fields.get("charVal") is not None
+    assert len(cs.myStruct.fields) == 1
+    assert cs.myStruct.fields.get("charVal")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -150,5 +150,5 @@ def test_includes(cs: cstruct) -> None:
     assert len(cs.includes) == 2
     assert cs.myStruct.__name__ == "myStruct"
     assert len(cs.typedefs["myStruct"].fields) == 1
-    assert not (cs.typedefs["myStruct"].fields.get("charVal") == None)
+    assert cs.typedefs["myStruct"].fields.get("charVal") is not None
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -150,5 +150,5 @@ def test_includes(cs: cstruct) -> None:
     assert len(cs.includes) == 2
     assert cs.myStruct.__name__ == "myStruct"
     assert len(cs.typedefs["myStruct"].fields) == 1
-    assert cs.typedefs["myStruct"].fields.get("charVal") != None
+    assert not (cs.typedefs["myStruct"].fields.get("charVal") == None)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -129,3 +129,26 @@ def test_structure_names(cs: cstruct) -> None:
     assert cs.c.__name__ == "c"
     assert cs.d.__name__ == "c"
     assert cs.e.__name__ == "e"
+
+
+def test_structure_names(cs: cstruct) -> None:
+    cdef = """
+    /* Standard libs */
+    #include <stdint.h> // defines fixed data types: int8_t...
+    /* user libs */
+    #include "myLib.h"  // my own header
+
+    typedef struct myStruct
+    {
+        char charVal[16];
+    }
+    """
+    cs.load(cdef)
+
+    assert cs.includes[0] == "<stdint.h>"
+    assert cs.includes[1] == "\"myLib.h\""
+    assert len(cs.includes) == 2
+    assert cs.myStruct.__name__ == "myStruct"
+    assert len(cs.typedefs["myStruct"].fields) == 1
+    assert cs.typedefs["myStruct"].fields.get("charVal") != None
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -131,7 +131,7 @@ def test_structure_names(cs: cstruct) -> None:
     assert cs.e.__name__ == "e"
 
 
-def test_structure_names(cs: cstruct) -> None:
+def test_includes(cs: cstruct) -> None:
     cdef = """
     /* Standard libs */
     #include <stdint.h> // defines fixed data types: int8_t...

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -146,7 +146,7 @@ def test_structure_names(cs: cstruct) -> None:
     cs.load(cdef)
 
     assert cs.includes[0] == "<stdint.h>"
-    assert cs.includes[1] == "\"myLib.h\""
+    assert cs.includes[1] == "myLib.h"
     assert len(cs.includes) == 2
     assert cs.myStruct.__name__ == "myStruct"
     assert len(cs.typedefs["myStruct"].fields) == 1


### PR DESCRIPTION
Add support for key ```#include```

This PR implements parsing capability for the key ```#include "myLib.h"```. It parses all includes in a list. Following example:

```python
from dissect.cstruct import cstruct

cdef = """
/* Standard libs */
#include <stdint.h> // defines fixed data types: int8_t...
#include "myLib.h"  // my own header

typedef struct myStruct
{
    char        charVal[16];
}

"""
cs = cstruct()
cs.load(cdef)
print(cs.includes)
```

Leads to the output: ```['<stdint.h>', '"myLib.h"']```

Thanks for merging.


BR,
Andreas