### PR TITLE
Add support for combined name and pointer typedef

### DIFF
--- a/dissect/cstruct/parser.py
+++ b/dissect/cstruct/parser.py
@@ -314,11 +314,11 @@ class TokenParser(Parser):
                 tokens.eol()
                 break
 
-            if tokens.next not in (self.TOK.NAME, self.TOK.DEFS):
+            if tokens.next not in (self.TOK.NAME, self.TOK.DEFS, self.TOK.IDENTIFIER):
                 break
 
             ntoken = tokens.consume()
-            if ntoken == self.TOK.NAME:
+            if ntoken in (self.TOK.NAME, self.TOK.IDENTIFIER):
                 names.append(ntoken.value.strip())
             elif ntoken == self.TOK.DEFS:
                 names.extend([name.strip() for name in ntoken.value.strip().split(",")])

--- a/dissect/cstruct/tools/stubgen.py
+++ b/dissect/cstruct/tools/stubgen.py
@@ -92,6 +92,9 @@ def generate_cstruct_stub(cs: cstruct, module_prefix: str = "", cls_name: str = 
             stub = f"{name}: TypeAlias = {typedef.__name__}"
         elif issubclass(typedef, (types.Enum, types.Flag)):
             stub = generate_enum_stub(typedef, cs_prefix=cs_prefix, module_prefix=module_prefix)
+        elif issubclass(typedef, types.Pointer):
+            typehint = generate_typehint(typedef, prefix=cs_prefix, module_prefix=module_prefix)
+            stub = f"{name}: TypeAlias = {typehint}"
         elif issubclass(typedef, types.Structure):
             stub = generate_structure_stub(typedef, cs_prefix=cs_prefix, module_prefix=module_prefix)
         elif issubclass(typedef, types.BaseType):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,7 +7,7 @@ import pytest
 
 from dissect.cstruct.exceptions import ParserError
 from dissect.cstruct.parser import TokenParser
-from dissect.cstruct.types import BaseArray, Pointer
+from dissect.cstruct.types import BaseArray, Pointer, Structure
 from tests.utils import verify_compiled
 
 if TYPE_CHECKING:
@@ -149,3 +149,18 @@ def test_includes(cs: cstruct) -> None:
     assert cs.myStruct.__name__ == "myStruct"
     assert len(cs.myStruct.fields) == 1
     assert cs.myStruct.fields.get("charVal")
+
+
+def test_typedef_pointer(cs: cstruct) -> None:
+    cdef = """
+    typedef struct _IMAGE_DATA_DIRECTORY {
+        DWORD VirtualAddress;
+        DWORD Size;
+    } IMAGE_DATA_DIRECTORY, *PIMAGE_DATA_DIRECTORY;
+    """
+    cs.load(cdef)
+
+    assert issubclass(cs._IMAGE_DATA_DIRECTORY, Structure)
+    assert cs.IMAGE_DATA_DIRECTORY is cs._IMAGE_DATA_DIRECTORY
+    assert issubclass(cs.PIMAGE_DATA_DIRECTORY, Pointer)
+    assert cs.PIMAGE_DATA_DIRECTORY.type == cs._IMAGE_DATA_DIRECTORY

--- a/tests/test_tools_stubgen.py
+++ b/tests/test_tools_stubgen.py
@@ -319,6 +319,26 @@ def test_generate_structure_stub(cs: cstruct, cdef: str, expected: str) -> None:
             """,
             id="define literals",
         ),
+        pytest.param(
+            """
+            typedef struct _Test {
+                uint8 a;
+            } Test, *pTest;
+            """,
+            """
+            class cstruct(cstruct):
+                class _Test(Structure):
+                    a: cstruct.uint8
+                    @overload
+                    def __init__(self, a: cstruct.uint8 | None = ...): ...
+                    @overload
+                    def __init__(self, fh: bytes | memoryview | bytearray | BinaryIO, /): ...
+
+                Test: TypeAlias = _Test
+                pTest: TypeAlias = Pointer[cstruct._Test]
+            """,
+            id="pointer alias",
+        ),
     ],
 )
 def test_generate_cstruct_stub(cs: cstruct, cdef: str, expected: str) -> None:


### PR DESCRIPTION
Fixes #132.

Allows more easy copy/pasting from Microsoft and other structure definitions such as:

```c
typedef struct _IMAGE_DATA_DIRECTORY {
    DWORD VirtualAddress;
    DWORD Size;
} IMAGE_DATA_DIRECTORY, *PIMAGE_DATA_DIRECTORY;
```

With this PR it correctly parses `IMAGE_DATA_DIRECTORY` and `*PIMAGE_DATA_DIRECTORY`.