### PR TITLE
Allow cstruct class initialization with definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Optimize storage of field sizes.
 - Rename `_sizes` property of `Structure` to `__sizes__`.
 - Rename `_values` property of `Structure` to `__values__`.
-- Added `load` argument to `cstruct` class, other arguments to `cstruct` are now keyword only.
+- Added `load` argument to `cstruct` class, allowing direct initialization with a definition (i.e. `cstruct(cdef)` instead of `cstruct().load(cdef)`. Other arguments to `cstruct` are now keyword only.
 
 ## [4.5] - 20-05-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Optimize storage of field sizes.
 - Rename `_sizes` property of `Structure` to `__sizes__`.
 - Rename `_values` property of `Structure` to `__values__`.
+- Added `load` argument to `cstruct` class, other arguments to `cstruct` are now keyword only.
 
 ## [4.5] - 20-05-2025
 

--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -189,7 +189,7 @@ class cstruct:
         self._anonymous_count = 0
 
         if load:
-            TokenParser(self).parse(load)
+            self.load(load)
 
     def __getattr__(self, attr: str) -> Any:
         try:

--- a/dissect/cstruct/cstruct.py
+++ b/dissect/cstruct/cstruct.py
@@ -48,7 +48,7 @@ class cstruct:
     DEF_CSTYLE = 1
     DEF_LEGACY = 2
 
-    def __init__(self, endian: str = "<", pointer: str | None = None):
+    def __init__(self, load: str = "", *, endian: str = "<", pointer: str | None = None):
         self.endian = endian
 
         self.consts = {}
@@ -187,6 +187,9 @@ class cstruct:
         pointer = pointer or ("uint64" if sys.maxsize > 2**32 else "uint32")
         self.pointer: type[BaseType] = self.resolve(pointer)
         self._anonymous_count = 0
+
+        if load:
+            TokenParser(self).parse(load)
 
     def __getattr__(self, attr: str) -> Any:
         try:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -77,7 +77,7 @@ def test_load_init_kwargs_only() -> None:
     """
 
     # kwargs only check
-    with pytest.raises(TypeError, match=r"cstruct.__init__\(\) takes from .* positional arguments but \d+ were given"):
+    with pytest.raises(TypeError, match="takes from .* positional arguments but .* were given"):
         cs = cstruct(cdef, ">")
 
     cs = cstruct(cdef, endian=">")


### PR DESCRIPTION
This quality of life improvement allows the user to directly initialize a `cstruct` object using a c-definition.

This change also enforces that `endian` or `pointer` arguments (and future arguments) must be passed using keyword arguments only. It seems that no code base used positional arguments for this before (checked using github codesearch), but this is a breaking change if someone did.

Tests are included.

<!--
Thank you for submitting a Pull Request. Please:
* Read our commit style guide:
    Commit messages should adhere to the following points:
    * Separate subject from body with a blank line
    * Limit the subject line to 50 characters as much as possible
    * Capitalize the subject line
    * Do not end the subject line with a period
    * Use the imperative mood in the subject line
    * The verb should represent what was accomplished (Create, Add, Fix etc)
    * Wrap the body at 72 characters
    * Use the body to explain the what and why vs. the how
  For an example, look at the following link:
  https://docs.dissect.tools/en/latest/contributing/style-guide.html#example-commit-message

* Include a description of the proposed changes and how to test them.

* After creation, associate the PR with an issue, under the development section.
  Or use closing keywords in the body during creation:
  E.G:
  * close(|s|d) #<nr>
  * fix(|es|ed) #<nr>
  * resolve(|s|d) #<nr>
-->
resolves #133
