### PR TITLE
Harmonization of ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ select = [
 ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003"]
 
 [tool.ruff.lint.per-file-ignores]
+"tests/**" = ["S101", "PLC0415"]
 "tests/_docs/**" = ["INP001"]
 
 [tool.ruff.lint.isort]

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -21,7 +21,7 @@ def test_cstruct_type_annotation(name: str, monkeypatch: pytest.MonkeyPatch) -> 
         for module in [module for module in sys.modules if module in ("dissect.cstruct.cstruct")]:
             monkeypatch.delitem(sys.modules, module)
 
-        from dissect.cstruct import cstruct  # noqa: PLC0415
+        from dissect.cstruct import cstruct
 
         if name.startswith("__"):
             name = f"_cstruct{name}"


### PR DESCRIPTION
In the global ruff config for the monorepo we have

```
[lint.per-file-ignores]
"**tests/**" = ["S101", "PLC0415"]
```