### PR TITLE
Add pretty print to hexdump

### DIFF
--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Literal
 
+# Bold ANSI colors
 COLOR_RED = "\033[1;31m"
 COLOR_GREEN = "\033[1;32m"
 COLOR_YELLOW = "\033[1;33m"
@@ -22,6 +23,10 @@ COLOR_CYAN = "\033[1;36m"
 COLOR_WHITE = "\033[1;37m"
 COLOR_NORMAL = "\033[1;0m"
 
+# Regular ANSI colors
+COLOR_BLACK_REG = "\033[0;30m"
+
+# Background ANSI colors
 COLOR_BG_RED = "\033[1;41m\033[1;37m"
 COLOR_BG_GREEN = "\033[1;42m\033[1;37m"
 COLOR_BG_YELLOW = "\033[1;43m\033[1;37m"
@@ -44,17 +49,41 @@ ENDIANNESS_MAP: dict[str, Literal["big", "little"]] = {
 Palette = list[tuple[int, str]]
 
 
-def _hexdump(data: bytes, palette: Palette | None = None, offset: int = 0, prefix: str = "") -> Iterator[str]:
+def human_colors() -> dict[str, str]:
+    """Generate a dictionary of characters with a human-readable ANSI color they should be in a hexdump."""
+    colors = {
+        "\00": COLOR_BLACK_REG,
+        # ...
+    }
+    # approx. 0x20-0x7E
+    for char in PRINTABLE:
+        colors[char] = COLOR_WHITE
+
+    # ... other coloring rules here ...
+    return colors
+
+
+HUMAN_COLORS = human_colors()
+
+
+def _hexdump(
+    data: bytes, palette: Palette | None = None, offset: int = 0, prefix: str = "", pretty: bool = False
+) -> Iterator[str]:
     """Hexdump some data.
 
     Args:
         data: Bytes to hexdump.
+        palette: Colorize the hexdump using this color pattern.
         offset: Byte offset of the hexdump.
         prefix: Optional prefix.
-        palette: Colorize the hexdump using this color pattern.
+        pretty: Use pretty colors, mutual exclusive with palette.
     """
     if palette:
         palette = palette[::-1]
+
+    # only happy little accidents
+    if pretty and palette:
+        raise ValueError("Cannot use argument 'pretty' in combination with 'palette', please pick one")
 
     remaining = 0
     active = None
@@ -89,8 +118,12 @@ def _hexdump(data: bytes, palette: Palette | None = None, offset: int = 0, prefi
                     values += f"{ord(char):02x}"
                     chars.append(active + print_char + COLOR_NORMAL)
                 else:
-                    values += f"{ord(char):02x}"
-                    chars.append(print_char)
+                    if pretty and (color := HUMAN_COLORS.get(char, "")):
+                        values += f"{color}{ord(char):02x}{COLOR_NORMAL}"
+                        chars.append(color + print_char + COLOR_NORMAL)
+                    else:
+                        values += f"{ord(char):02x}"
+                        chars.append(print_char)
 
                 remaining -= 1
                 if remaining == 0:
@@ -111,7 +144,12 @@ def _hexdump(data: bytes, palette: Palette | None = None, offset: int = 0, prefi
 
 
 def hexdump(
-    data: bytes, palette: Palette | None = None, offset: int = 0, prefix: str = "", output: str = "print"
+    data: bytes,
+    palette: Palette | None = None,
+    offset: int = 0,
+    prefix: str = "",
+    output: str = "print",
+    pretty: bool = False,
 ) -> Iterator[str] | str | None:
     """Hexdump some data.
 
@@ -121,8 +159,9 @@ def hexdump(
         offset: Byte offset of the hexdump.
         prefix: Optional prefix.
         output: Output format, can be 'print', 'generator' or 'string'.
+        pretty: Use pretty colors for improved human readability.
     """
-    generator = _hexdump(data, palette, offset, prefix)
+    generator = _hexdump(data, palette, offset, prefix, pretty)
     if output == "print":
         print("\n".join(generator))
         return None

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -191,11 +191,11 @@ def hexdump(
         output: Output format, can be 'print', 'generator' or 'string'.
         pretty: Use pretty colors for improved human readability.
     """
-    _pretty = (
+    pretty = (
         True if output == "print" and not palette and pretty is not False and not os.environ.get("NO_COLOR") else pretty
     )
 
-    generator = _hexdump(data, palette, offset, prefix, _pretty)
+    generator = _hexdump(data, palette, offset, prefix, pretty)
     if output == "print":
         print("\n".join(generator))
         return None

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -55,7 +55,7 @@ ENDIANNESS_MAP: dict[str, Literal["big", "little"]] = {
 Palette = list[tuple[int, str]]
 
 
-def human_colors() -> dict[str, str]:
+def _human_colors() -> dict[str, str]:
     """Generates a dictionary of characters with a human-readable ANSI color they should be in a hexdump.
 
     Coloring logic implementation derived from HexFriend and ImHex.
@@ -82,7 +82,7 @@ def human_colors() -> dict[str, str]:
     return colors
 
 
-HUMAN_COLORS = human_colors()
+HUMAN_COLORS = _human_colors()
 
 
 def _hexdump(

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -14,21 +14,27 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from typing import Literal
 
-# Bold ANSI colors
-COLOR_RED = "\033[1;31m"
-COLOR_GREEN = "\033[1;32m"
-COLOR_YELLOW = "\033[1;33m"
-COLOR_BLUE = "\033[1;34m"
-COLOR_PURPLE = "\033[1;35m"
-COLOR_CYAN = "\033[1;36m"
-COLOR_WHITE = "\033[1;37m"
-COLOR_NORMAL = "\033[1;0m"
-
 # Regular ANSI colors
-COLOR_BLACK_REG = "\033[0;30m"
-COLOR_GREY_REG = "\033[0;90m"
-COLOR_GREEN_REG = "\033[0;32m"
-COLOR_YELLOW_REG = "\033[0;93m"
+COLOR_RED = ""
+COLOR_GREEN = "\033[0;32m"
+COLOR_YELLOW = "\033[0;93m"
+COLOR_BLUE = "\033[0;34m"
+COLOR_PURPLE = "\033[0;35m"
+COLOR_CYAN = "\033[0;36m"
+COLOR_WHITE = "\033[0;37m"
+COLOR_BLACK = "\033[0;30m"
+COLOR_GREY = "\033[0;90m"
+
+# Bold ANSI colors
+COLOR_RED_BOLD = "\033[1;31m"
+COLOR_GREEN_BOLD = "\033[1;32m"
+COLOR_YELLOW_BOLD = "\033[1;33m"
+COLOR_BLUE_BOLD = "\033[1;34m"
+COLOR_PURPLE_BOLD = "\033[1;35m"
+COLOR_CYAN_BOLD = "\033[1;36m"
+COLOR_WHITE_BOLD = "\033[1;37m"
+COLOR_BLACK_BOLD = "\033[1;30m"
+COLOR_GREY_BOLD = "\033[1;90m"
 
 # Background ANSI colors
 COLOR_BG_RED = "\033[1;41m\033[1;37m"
@@ -39,7 +45,9 @@ COLOR_BG_PURPLE = "\033[1;45m\033[1;37m"
 COLOR_BG_CYAN = "\033[1;46m\033[1;37m"
 COLOR_BG_WHITE = "\033[1;47m\033[1;30m"
 
+# Reset ANSI codes
 COLOR_CLEAR = "\033[0m"
+COLOR_CLEAR_BOLD = "\033[1;0m"
 
 PRINTABLE = string.digits + string.ascii_letters + string.punctuation + " "
 
@@ -61,23 +69,23 @@ def _human_colors() -> dict[str, str]:
     Coloring logic implementation derived from HexFriend and ImHex.
     """
     # Make all characters not in any rules below light green
-    colors = {chr(char): COLOR_GREEN_REG for char in range(256)}
+    colors = {chr(char): COLOR_GREEN for char in range(256)}
 
     # Make all ASCII extended characters yellow
     for char in colors:
         if ord(char) & 0x80 == 0:
-            colors[char] = COLOR_YELLOW_REG
+            colors[char] = COLOR_YELLOW
 
     # Make null bytes grey
-    colors["\00"] = COLOR_GREY_REG
+    colors["\00"] = COLOR_GREY
 
     # Make printable ASCII characters bold white (0x32-0x7E)
     for char in PRINTABLE:
-        colors[char] = COLOR_WHITE
+        colors[char] = COLOR_WHITE_BOLD
 
     # Make ASCII whitespace characters green bold (0x9, 0xA, 0xB, 0xC, 0xD, 0x20)
     for char in ("\t", "\n", "\11", "\12", "\r", "\20"):
-        colors[char] = COLOR_GREEN
+        colors[char] = COLOR_GREEN_BOLD
 
     return colors
 
@@ -135,7 +143,7 @@ def _hexdump(
 
                 if active:
                     values += f"{ord(char):02x}"
-                    chars.append(active + print_char + COLOR_CLEAR)
+                    chars.append(active + print_char + COLOR_CLEAR_BOLD)
                 else:
                     if pretty and (color := HUMAN_COLORS.get(char, "")):
                         values += f"{color}{ord(char):02x}{COLOR_CLEAR}"
@@ -149,10 +157,10 @@ def _hexdump(
                     active = None
 
                     if palette is not None:
-                        values += COLOR_CLEAR
+                        values += COLOR_CLEAR_BOLD
 
                 if j == 15 and palette is not None:
-                    values += COLOR_CLEAR
+                    values += COLOR_CLEAR_BOLD
 
             values += " "
             if j == 7:
@@ -207,13 +215,13 @@ def _dumpstruct(
 ) -> str | None:
     palette = []
     colors = [
-        (COLOR_RED, COLOR_BG_RED),
-        (COLOR_GREEN, COLOR_BG_GREEN),
-        (COLOR_YELLOW, COLOR_BG_YELLOW),
-        (COLOR_BLUE, COLOR_BG_BLUE),
-        (COLOR_PURPLE, COLOR_BG_PURPLE),
-        (COLOR_CYAN, COLOR_BG_CYAN),
-        (COLOR_WHITE, COLOR_BG_WHITE),
+        (COLOR_RED_BOLD, COLOR_BG_RED),
+        (COLOR_GREEN_BOLD, COLOR_BG_GREEN),
+        (COLOR_YELLOW_BOLD, COLOR_BG_YELLOW),
+        (COLOR_BLUE_BOLD, COLOR_BG_BLUE),
+        (COLOR_PURPLE_BOLD, COLOR_BG_PURPLE),
+        (COLOR_CYAN_BOLD, COLOR_BG_CYAN),
+        (COLOR_WHITE_BOLD, COLOR_BG_WHITE),
     ]
     ci = 0
     out = [f"struct {structure.__class__.__name__}:"]
@@ -237,7 +245,7 @@ def _dumpstruct(
             size = structure.__sizes__[field._name]
             palette.append((size, background))
             ci += 1
-            out.append(f"- {foreground}{field._name}{COLOR_NORMAL}: {value}")
+            out.append(f"- {foreground}{field._name}{COLOR_CLEAR_BOLD}: {value}")
         else:
             out.append(f"- {field._name}: {value}")
 

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import pprint
 import string
 import sys
@@ -25,6 +26,9 @@ COLOR_NORMAL = "\033[1;0m"
 
 # Regular ANSI colors
 COLOR_BLACK_REG = "\033[0;30m"
+COLOR_GREY_REG = "\033[0;90m"
+COLOR_GREEN_REG = "\033[0;32m"
+COLOR_YELLOW_REG = "\033[0;93m"
 
 # Background ANSI colors
 COLOR_BG_RED = "\033[1;41m\033[1;37m"
@@ -34,6 +38,8 @@ COLOR_BG_BLUE = "\033[1;44m\033[1;37m"
 COLOR_BG_PURPLE = "\033[1;45m\033[1;37m"
 COLOR_BG_CYAN = "\033[1;46m\033[1;37m"
 COLOR_BG_WHITE = "\033[1;47m\033[1;30m"
+
+COLOR_CLEAR = "\033[0m"
 
 PRINTABLE = string.digits + string.ascii_letters + string.punctuation + " "
 
@@ -50,16 +56,29 @@ Palette = list[tuple[int, str]]
 
 
 def human_colors() -> dict[str, str]:
-    """Generate a dictionary of characters with a human-readable ANSI color they should be in a hexdump."""
-    colors = {
-        "\00": COLOR_BLACK_REG,
-        # ...
-    }
-    # approx. 0x20-0x7E
+    """Generates a dictionary of characters with a human-readable ANSI color they should be in a hexdump.
+
+    Coloring logic implementation derived from HexFriend and ImHex.
+    """
+    # Make all characters not in any rules below light green
+    colors = {chr(char): COLOR_GREEN_REG for char in range(256)}
+
+    # Make all ASCII extended characters yellow
+    for char in colors:
+        if ord(char) & 0x80 == 0:
+            colors[char] = COLOR_YELLOW_REG
+
+    # Make null bytes grey
+    colors["\00"] = COLOR_GREY_REG
+
+    # Make printable ASCII characters bold white (0x32-0x7E)
     for char in PRINTABLE:
         colors[char] = COLOR_WHITE
 
-    # ... other coloring rules here ...
+    # Make ASCII whitespace characters green bold (0x9, 0xA, 0xB, 0xC, 0xD, 0x20)
+    for char in ("\t", "\n", "\11", "\12", "\r", "\20"):
+        colors[char] = COLOR_GREEN
+
     return colors
 
 
@@ -67,7 +86,7 @@ HUMAN_COLORS = human_colors()
 
 
 def _hexdump(
-    data: bytes, palette: Palette | None = None, offset: int = 0, prefix: str = "", pretty: bool = False
+    data: bytes, palette: Palette | None = None, offset: int = 0, prefix: str = "", pretty: bool | None = False
 ) -> Iterator[str]:
     """Hexdump some data.
 
@@ -116,11 +135,11 @@ def _hexdump(
 
                 if active:
                     values += f"{ord(char):02x}"
-                    chars.append(active + print_char + COLOR_NORMAL)
+                    chars.append(active + print_char + COLOR_CLEAR)
                 else:
                     if pretty and (color := HUMAN_COLORS.get(char, "")):
-                        values += f"{color}{ord(char):02x}{COLOR_NORMAL}"
-                        chars.append(color + print_char + COLOR_NORMAL)
+                        values += f"{color}{ord(char):02x}{COLOR_CLEAR}"
+                        chars.append(color + print_char + COLOR_CLEAR)
                     else:
                         values += f"{ord(char):02x}"
                         chars.append(print_char)
@@ -130,10 +149,10 @@ def _hexdump(
                     active = None
 
                     if palette is not None:
-                        values += COLOR_NORMAL
+                        values += COLOR_CLEAR
 
                 if j == 15 and palette is not None:
-                    values += COLOR_NORMAL
+                    values += COLOR_CLEAR
 
             values += " "
             if j == 7:
@@ -149,9 +168,12 @@ def hexdump(
     offset: int = 0,
     prefix: str = "",
     output: str = "print",
-    pretty: bool = False,
+    pretty: bool | None = None,
 ) -> Iterator[str] | str | None:
     """Hexdump some data.
+
+    Uses colored ANSI output with output type "print" by default. Disable with ``pretty=False``
+    or set the environment variable ``NO_COLOR``.
 
     Args:
         data: Bytes to hexdump.
@@ -161,7 +183,11 @@ def hexdump(
         output: Output format, can be 'print', 'generator' or 'string'.
         pretty: Use pretty colors for improved human readability.
     """
-    generator = _hexdump(data, palette, offset, prefix, pretty)
+    _pretty = (
+        True if output == "print" and not palette and pretty is not False and not os.environ.get("NO_COLOR") else pretty
+    )
+
+    generator = _hexdump(data, palette, offset, prefix, _pretty)
     if output == "print":
         print("\n".join(generator))
         return None

--- a/dissect/cstruct/utils.py
+++ b/dissect/cstruct/utils.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
 # Regular ANSI colors
-COLOR_RED = ""
+COLOR_RED = "\033[0;31m"
 COLOR_GREEN = "\033[0;32m"
 COLOR_YELLOW = "\033[0;93m"
 COLOR_BLUE = "\033[0;34m"
@@ -191,9 +191,14 @@ def hexdump(
         output: Output format, can be 'print', 'generator' or 'string'.
         pretty: Use pretty colors for improved human readability.
     """
-    pretty = (
-        True if output == "print" and not palette and pretty is not False and not os.environ.get("NO_COLOR") else pretty
-    )
+    # Enable pretty colors by default if ...
+    if (
+        output == "print"  # the output type is set to 'print'
+        and not palette  # no palette is given (structdump only)
+        and pretty is not False  # pretty was not explicitly set to False
+        and not os.environ.get("NO_COLOR")  # and the environment allows colors
+    ):
+        pretty = True
 
     generator = _hexdump(data, palette, offset, prefix, pretty)
     if output == "print":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,9 +33,9 @@ def test_hexdump(capsys: pytest.CaptureFixture) -> None:
 def test_hexdump_pretty(capsys: pytest.CaptureFixture) -> None:
     """Check if we can create a pretty hexdump."""
     c = utils.COLOR_CLEAR
-    g = utils.COLOR_GREY_REG
-    w = utils.COLOR_WHITE
-    y = utils.COLOR_YELLOW_REG
+    g = utils.COLOR_GREY
+    w = utils.COLOR_WHITE_BOLD
+    y = utils.COLOR_YELLOW
 
     utils.hexdump((b"\x00" * 5) + b"\x01\x02\x03abc" + (b"\x00" * 5), pretty=True)
     captured = capsys.readouterr()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,6 +30,28 @@ def test_hexdump(capsys: pytest.CaptureFixture) -> None:
         utils.hexdump("b\x00", output="str")
 
 
+def test_hexdump_pretty(capsys: pytest.CaptureFixture) -> None:
+    """Check if we can create a pretty hexdump."""
+    n = utils.COLOR_NORMAL
+    b = utils.COLOR_BLACK_REG
+    w = utils.COLOR_WHITE
+
+    utils.hexdump((b"\x00" * 5) + b"\x01\x02\x03abc" + (b"\x00" * 5), pretty=True)
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == "00000000  "
+        + (f"{b}00{n} " * 5)
+        + f"01 02 03  {w}61{n} {w}62{n} {w}63{n} "
+        + (f"{b}00{n} " * 5)
+        + "  "
+        + (f"{b}.{n}" * 5)
+        + f"...{w}a{n}{w}b{n}{w}c{n}"
+        + (f"{b}.{n}" * 5)
+        + "\n"
+    )
+
+
 def test_dumpstruct(cs: cstruct, capsys: pytest.CaptureFixture, compiled: bool) -> None:
     cdef = """
     struct test {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def test_hexdump(capsys: pytest.CaptureFixture) -> None:
-    utils.hexdump(b"\x00" * 16)
+    utils.hexdump(b"\x00" * 16, pretty=False)
     captured = capsys.readouterr()
     assert captured.out == "00000000  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   ................\n"
 
@@ -32,24 +32,45 @@ def test_hexdump(capsys: pytest.CaptureFixture) -> None:
 
 def test_hexdump_pretty(capsys: pytest.CaptureFixture) -> None:
     """Check if we can create a pretty hexdump."""
-    n = utils.COLOR_NORMAL
-    b = utils.COLOR_BLACK_REG
+    c = utils.COLOR_CLEAR
+    g = utils.COLOR_GREY_REG
     w = utils.COLOR_WHITE
+    y = utils.COLOR_YELLOW_REG
 
     utils.hexdump((b"\x00" * 5) + b"\x01\x02\x03abc" + (b"\x00" * 5), pretty=True)
     captured = capsys.readouterr()
     assert (
         captured.out
         == "00000000  "
-        + (f"{b}00{n} " * 5)
-        + f"01 02 03  {w}61{n} {w}62{n} {w}63{n} "
-        + (f"{b}00{n} " * 5)
+        + (f"{g}00{c} " * 5)
+        + f"{y}01{c} {y}02{c} {y}03{c}  {w}61{c} {w}62{c} {w}63{c} "
+        + (f"{g}00{c} " * 5)
         + "  "
-        + (f"{b}.{n}" * 5)
-        + f"...{w}a{n}{w}b{n}{w}c{n}"
-        + (f"{b}.{n}" * 5)
+        + (f"{g}.{c}" * 5)
+        + f"{y}.{c}{y}.{c}{y}.{c}{w}a{c}{w}b{c}{w}c{c}"
+        + (f"{g}.{c}" * 5)
         + "\n"
     )
+
+
+def test_hexdump_pretty_print_conditions(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test if we respec the ``NO_COLOR`` environment variable and ``pretty=False`` argument."""
+    # Test regular print output behavior
+    utils.hexdump(b"\x00" * 16)
+    captured = capsys.readouterr()
+    assert captured.out.startswith("00000000  \x1b[0;90m00")
+
+    # Test explicit disable using NO_COLOR
+    with monkeypatch.context() as m:
+        m.setenv("NO_COLOR", "1")
+        utils.hexdump(b"\x00" * 16)
+        captured = capsys.readouterr()
+        assert captured.out.startswith("00000000  00")
+
+    # Test explicit disable using pretty=False
+    utils.hexdump(b"\x00" * 16, pretty=False)
+    captured = capsys.readouterr()
+    assert captured.out.startswith("00000000  00")
 
 
 def test_dumpstruct(cs: cstruct, capsys: pytest.CaptureFixture, compiled: bool) -> None:


### PR DESCRIPTION
This PR aims to provide a stub for pretty colors as described in #80. Currently only null bytes are 'greyed-out' and ASCII printable characters are whitened. 

<img width="784" height="210" alt="image" src="https://github.com/user-attachments/assets/31d5eda1-9343-4e28-a2fe-b7ea0a51a73a" />

---

Perhaps we can look at some of these resources to determine what other coloring rules we would like to apply here:
* https://simonomi.dev/blog/color-code-your-bytes/
* http://thestone.zone/hacking/2019/01/01/hacking-quest-for-glory.html

Some things that come to mind:
* Should we show difference between certain printable ASCII characters (letters, numbers, capitalization, etc.)?
* Should we color white space characters (`0x09-0x0D`, `0x20`, etc.)?
* What about non-ASCII (`0x80-0xFF`)?

The current implementation does not change the default behavior of `hexdump`, using the `pretty` argument is required.